### PR TITLE
Added support for running in browser

### DIFF
--- a/lib/plist.js
+++ b/lib/plist.js
@@ -1,23 +1,38 @@
 ;(function (exports, sax) {
-	var inNode = typeof window === 'undefined' ? true : false;
+	var inNode = typeof window === 'undefined' ? true : false; //Checks if running in a non-browser environment
+	
 	function Parser() {
 		sax.SAXParser.call(this, false, { lowercasetags: true, trim: false });
 	}
-	var fs = inNode ? require('fs') : {};
-	var util = inNode ? require('util') : {
-		inherits: function(ctor, superCtor) {
-			ctor.super_ = superCtor;
-			ctor.prototype = Object.create(superCtor.prototype, {
-				constructor: {
-					value: ctor,
-					enumerable: false,
-					writable: true,
-					configurable: true
-				}
-			});
+	
+	var inherits = null;
+	if (inNode) {
+		var fs = require('fs');
+		inherits = require('util').inherit; //use node provided function
+	}else{ //use in browser
+		if ("create" in Object) {
+			inherits = function(ctor, superCtor) {
+				ctor.super_ = superCtor;
+				ctor.prototype = Object.create(superCtor.prototype, {
+					constructor: {
+						value: ctor,
+						enumerable: false,
+						writable: true,
+						configurable: true
+					}
+				});
+			};
+		} else {
+			var klass = function() {};
+			inherits = function(ctor, superCtor) {
+				klass.prototype = superCtor.prototype;
+				ctor.prototype = new klass;
+				ctor.prototype['constructor'] = ctor;
+			}
 		}
-	};
-	util.inherits(Parser, sax.SAXParser);
+	}
+	inherits(Parser, sax.SAXParser); //inherit from sax (browser-style or node-style)
+	
 	Parser.prototype.getInteger = function (string) {
 		this.value = parseInt(string, 10);
 	}
@@ -110,22 +125,22 @@
 			case 'dict':
 			case 'array':
 			case 'plist':
-			var value = this.context.value();
-			this.context = this.stack.pop();
-			this.context.setValue(value);
-			break;
+				var value = this.context.value();
+				this.context = this.stack.pop();
+				this.context.setValue(value);
+				break;
 			case 'true':
 			case 'false':
 			case 'string':
 			case 'integer':
 			case 'date':
 			case 'data':
-			this.context.setValue(this.value);
-			break;
+				this.context.setValue(this.value);
+				break;
 			case 'key':
-			break;
+				break;
 			default:
-			console.log('closing', tag, 'tag ignored');
+				console.log('closing', tag, 'tag ignored');
 		}
 		this.oncdata = this.ontext = this.checkWhitespace;
 	}
@@ -141,7 +156,7 @@
 		throw error;
 	}
 
-	if (inNode) Parser.prototype.parseFile = function (xmlfile, callback) {
+	if (inNode) Parser.prototype.parseFile = function (xmlfile, callback) { //browsers aren't capable of opening files, instead use AJAX
 		var parser = this;
 		parser.stack = [ ];
 		parser.context = {
@@ -181,8 +196,11 @@
 		parser.parseString(xml, callback);
 	}
 
-	if (inNode) exports.parseFile = function (filename, callback) {
+	if (inNode) exports.parseFile = function (filename, callback) { //Do not expose no created method
 		var parser = new Parser();
 		parser.parseFile(filename, callback);
 	}
-})(typeof exports === 'undefined' ? plist = {} : exports, typeof window === "undefined" ? require('sax') : sax) // TODO: Implement detection of 'sax' in the Browser environment
+})(typeof exports === 'undefined' ? plist = {} : exports, typeof window === "undefined" ? require('sax') : sax)
+//the above line checks for exports (defined in node) and uses it, or creates a global variable and exports to that.
+//also, if in node, require sax node-style, in browser the developer must use a <script> tag to import sax
+// TODO: Implement detection of 'sax' in the Browser environment


### PR DESCRIPTION
Now, node-plist can run in a browser. The parseFile method isn't
exposed, only parseString is available. Works.
Although GitHub thinks I changed all, I've only indented one space more. Check it in a better diff tool to see the actual modifications.
