### PR TITLE
Quick patch for <real> support

### DIFF
--- a/lib/plist.js
+++ b/lib/plist.js
@@ -8,7 +8,7 @@
 	var inherits = null;
 	if (inNode) {
 		var fs = require('fs');
-		inherits = require('util').inherit; //use node provided function
+		inherits = require('util').inherits; //use node provided function
 	}else{ //use in browser
 		if ("create" in Object) {
 			inherits = function(ctor, superCtor) {
@@ -35,6 +35,9 @@
 	
 	Parser.prototype.getInteger = function (string) {
 		this.value = parseInt(string, 10);
+	}
+	Parser.prototype.getReal = function (string) {
+		this.value = parseFloat(string);
 	}
 	Parser.prototype.getString = function (string) {
 		this.value += string;
@@ -95,6 +98,9 @@
 			case 'integer':
 				this.ontext = this.getInteger;
 				break;
+			case 'real':
+				this.ontext = this.getReal;
+				break;
 			case 'string':
 				this.value = '';
 				this.ontext = this.getString;
@@ -133,6 +139,7 @@
 			case 'false':
 			case 'string':
 			case 'integer':
+			case 'real':
 			case 'date':
 			case 'data':
 				this.context.setValue(this.value);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plist",
   "description": "Mac OS X Plist parser for NodeJS. Convert a Plist file or string into a native JS object",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Nathan Rajlich <nathan@tootallnate.net>",
   "contributors": [ "Hans Huebner <hans.huebner@gmail.com>" ],
   "repository": {

--- a/tests/airplay.xml
+++ b/tests/airplay.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>duration</key>
+  <real>5555.0495000000001</real>
+  <key>loadedTimeRanges</key>
+  <array>
+    <dict>
+      <key>duration</key>
+      <real>5555.0495000000001</real>
+      <key>start</key>
+      <real>0.0</real>
+    </dict>
+  </array>
+  <key>playbackBufferEmpty</key>
+  <true/>
+  <key>playbackBufferFull</key>
+  <false/>
+  <key>playbackLikelyToKeepUp</key>
+  <true/>
+  <key>position</key>
+  <real>4.6269989039999997</real>
+  <key>rate</key>
+  <real>1</real>
+  <key>readyToPlay</key>
+  <true/>
+  <key>seekableTimeRanges</key>
+  <array>
+    <dict>
+      <key>duration</key>
+      <real>5555.0495000000001</real>
+      <key>start</key>
+      <real>0.0</real>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/tests/test.js
+++ b/tests/test.js
@@ -37,3 +37,22 @@ plist.parseFile(file2, function(err, dicts) {
   assert.equal(dict['PopupMenu'][2]['Key'], "\n        \n        #import &lt;Cocoa/Cocoa.h&gt;\n\n#import &lt;MacRuby/MacRuby.h&gt;\n\nint main(int argc, char *argv[])\n{\n  return macruby_main(\"rb_main.rb\", argc, argv);\n}\n\n");
 
 });
+
+
+// Third test...
+var file3 = path.join(__dirname, "airplay.xml");
+var startTime3 = new Date();
+
+plist.parseFile(file3, function(err, dicts) {
+  if (err) {
+    throw err;
+  }
+
+  var endTime = new Date();
+  console.log('Parsed "' + file3 + '" in ' + (endTime - startTime3) + 'ms');
+
+  var dict = dicts[0];
+  assert.equal(dict['duration'], 5555.0495000000001);
+  assert.equal(dict['position'], 4.6269989039999997);
+
+});


### PR DESCRIPTION
This patch adds support for <real> tags in the plist parser, as well as a test to check that it works.
