### PR TITLE
Write out elements as <string> instead of <data> if elements are not base64

### DIFF
--- a/lib/plist.js
+++ b/lib/plist.js
@@ -275,10 +275,10 @@
       var base64Matcher = new RegExp("^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$");
       //var base64Matcher = new RegExp("^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$");
       if (base64Matcher.test(next.replace(/\s/g,'')) && (next.length>125)) {
-        next_child.ele('string').raw(next);
+      	next_child.ele('data').raw(utf8_to_b64(next));
       } else {
       	// base64 encode the data
-      	next_child.ele('data').raw(utf8_to_b64(next));
+        next_child.ele('string').raw(next);
       }
     }
   };


### PR DESCRIPTION
TL;DR more often than not you want the the written out .plist file to be composed of `<string>` elements instead of `<data>` elements. Human readable, etc.

Pretty sure the base64 detection ends up firing the reverse logic at this point, see TooTallNate/node-plist#21

i.e., if the base64 regex matches, it should write out elements as `<data>`, not as `<string>`

Would love to see this merged in as the [cordova CLI tools](http://github.com/filmaj/cordova-client) writes out .plist files for use with Xcode. Xcode is not happy when certain elements it expects as `<string>` come back as `<data>`.
