### PR TITLE
Fixed global variable "plist" leak

### DIFF
--- a/lib/plist.js
+++ b/lib/plist.js
@@ -75,6 +75,7 @@
 
 	exports.parseStringSync = function (xml) {
 		var doc = new DOMParser().parseFromString(xml);
+    var plist;
 		if (doc.documentElement.nodeName !== 'plist') {
 			throw new Error('malformed document. First element should be <plist>');
 		}


### PR DESCRIPTION
When calling plist.parseStringSync it overwrites value of plist globally. It is because var is missing.
