### PR TITLE
Remove duplicate devDependencies key

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Mac OS X Plist parser/builder for NodeJS. Convert a Plist file or string into a native JS object and native JS object into a Plist file.",
   "version": "0.4.3",
   "author": "Nathan Rajlich <nathan@tootallnate.net>",
-  "contributors": [ 
+  "contributors": [
     "Hans Huebner <hans.huebner@gmail.com>",
     "Pierre Metrailler",
     "Mike Reinstein <reinstein.mike@gmail.com>",
@@ -34,6 +34,5 @@
   },
   "engines": {
     "node": ">= 0.1.100"
-  },
-  "devDependencies": {}
+  }
 }


### PR DESCRIPTION
Previously nodeunit would not install when running npm install because of this duplicated element in the package.json file and so npm test would fail when run.
