### PR TITLE
Require xmlbuilder if it is undefined

### DIFF
--- a/lib/plist.js
+++ b/lib/plist.js
@@ -295,7 +295,7 @@
     }
   };
 
-})(typeof exports === 'undefined' ? plist = {} : exports, typeof window === 'undefined' ? require('xmldom').DOMParser : null, typeof window === 'undefined' ? require('xmlbuilder') : xmlbuilder)
+})(typeof exports === 'undefined' ? plist = {} : exports, typeof window === 'undefined' ? require('xmldom').DOMParser : null, typeof xmlbuilder === 'undefined' ? require('xmlbuilder') : xmlbuilder)
 // the above line checks for exports (defined in node) and uses it, or creates
 // a global variable and exports to that. also, if in node, require DOMParser
 // node-style, in browser it should already be present


### PR DESCRIPTION
Previously this would only be required if window was undefined but checking instead for xmlbuilder being undefined allows this to be used in contexts that have a window but do not provide xmlbuilder.
