### PR TITLE
Make module work in node environments where `window` global is defined

### DIFF
--- a/lib/plist.js
+++ b/lib/plist.js
@@ -1,8 +1,11 @@
 ;(function (exports, DOMParser, xmlbuilder) {
 	// Checks if running in a non-browser environment
- 	var inNode = typeof window === 'undefined' ? true : false
- 	  , utf8_to_b64
- 	  , b64_to_utf8;
+
+	var inNode = typeof process !== "undefined" && process.versions && !!process.versions.node
+		  , utf8_to_b64
+		, b64_to_utf8;
+
+
 
  	// this library runs in browsers and nodejs, set up functions accordingly
  	if (inNode) {
@@ -295,7 +298,7 @@
     }
   };
 
-})(typeof exports === 'undefined' ? plist = {} : exports, typeof window === 'undefined' ? require('xmldom').DOMParser : null, typeof window === 'undefined' ? require('xmlbuilder') : xmlbuilder)
+})(typeof exports === 'undefined' ? plist = {} : exports, typeof require !== 'undefined' ? require('xmldom').DOMParser : null, typeof require !== 'undefined' ? require('xmlbuilder') : xmlbuilder)
 // the above line checks for exports (defined in node) and uses it, or creates
 // a global variable and exports to that. also, if in node, require DOMParser
 // node-style, in browser it should already be present


### PR DESCRIPTION
I submitted this previously from my master. This is the same PR, but from a branch so I can keep it isolated from other changes I need to make on master.

Previously, having `window` defined in the global context made this
module behave as if wasn't running in node. I am attempting to use it
in a node environment where there is also a global window object, so
the nature of the check is causing problems. This commit changes the
check… it tries to determine if we're running in Node (instead of if
we're _not_ running in Node) by looking for the `process.versions`
hash. It also always tries to use require if it exists, rather than
skipping it if we have a window defined.
