### PR TITLE
Don't log non-fatal errors

### DIFF
--- a/lib/plist.js
+++ b/lib/plist.js
@@ -65,7 +65,7 @@
 		console.warn('parseString is deprecated. Please use parseStringSync instead.');
 		var doc, error, plist;
 		try {
-			doc = new DOMParser().parseFromString(xml);
+			doc = buildDOMParser().parseFromString(xml);
 			plist = parsePlistXML(doc.documentElement);
 		} catch(e) {
 			error = e;
@@ -74,7 +74,7 @@
 	}
 
 	exports.parseStringSync = function (xml) {
-		var doc = new DOMParser().parseFromString(xml);
+		var doc = buildDOMParser().parseFromString(xml);
     var plist;
 		if (doc.documentElement.nodeName !== 'plist') {
 			throw new Error('malformed document. First element should be <plist>');
@@ -294,6 +294,11 @@
       }
     }
   };
+
+	function buildDOMParser() {
+		// prevent the parser from logging non-fatel errors
+		return new DOMParser({errorHandler: function() {}});
+	}
 
 })(typeof exports === 'undefined' ? plist = {} : exports, typeof window === 'undefined' ? require('xmldom').DOMParser : null, typeof window === 'undefined' ? require('xmlbuilder') : xmlbuilder)
 // the above line checks for exports (defined in node) and uses it, or creates


### PR DESCRIPTION
The default error handler of DOMParser logs to the console when it encounters non-fatal errors. This is creating a lot of noise for plists that have minor validity problems but still are able to be parsed successfully. This PR passes a no-op handler to the parser to suppress the logging. Fatal errors should still raise exceptions.
