### PR TITLE
Skip comments while reading plist/dict/array

### DIFF
--- a/lib/plist.js
+++ b/lib/plist.js
@@ -88,6 +88,12 @@
 		return plist;
 	}
 
+	function shouldIgnoreNode(node) {
+		return node.nodeType === 3	 // text
+			|| node.nodeType === 8	 // comment
+			|| node.nodeType === 4;	 // cdata
+	}
+
 	/**
 	 * convert an XML based plist document into a JSON representation
 	 *
@@ -103,7 +109,7 @@
 			new_arr = [];
 			for (i=0;i < node.childNodes.length;i++) {
 				// ignore comment nodes (text)
-				if (node.childNodes[i].nodeType !== 3) {
+				if (!shouldIgnoreNode(node.childNodes[i])) {
 					new_arr.push( parsePlistXML(node.childNodes[i]));
 				}
 			}
@@ -114,7 +120,7 @@
 			key = null;
 			for (i=0;i < node.childNodes.length;i++) {
 				// ignore comment nodes (text)
-				if (node.childNodes[i].nodeType !== 3) {
+				if (!shouldIgnoreNode(node.childNodes[i])) {
 					if (key === null) {
 						key = parsePlistXML(node.childNodes[i]);
 					} else {
@@ -129,7 +135,7 @@
 			new_arr = [];
 			for (i=0;i < node.childNodes.length;i++) {
 				// ignore comment nodes (text)
-				if (node.childNodes[i].nodeType !== 3) {
+				if (!shouldIgnoreNode(node.childNodes[i])) {
 					res = parsePlistXML(node.childNodes[i]);
 					if (res) new_arr.push( res );
 				}


### PR DESCRIPTION
Without this patch there are problems reading this:

``` xml
        <key>CFBundleName</key>
        <string>Emacs</string>
        <key>CFBundlePackageType</key>
        <string>APPL</string>
        <!-- This should be the emacs version number. --> *** get "undefined" key here and further keys are messed up.
        <key>CFBundleShortVersionString</key>
        <string>24.3</string>
        <key>CFBundleSignature</key>
        <string>EMAx</string>
        <!-- This SHOULD be a build number. -->
        <key>CFBundleVersion</key>
        <string>9.0</string>
```
