### PR TITLE
Updated DTD to reflect name change from Apple Computer to Apple

### DIFF
--- a/lib/plist.js
+++ b/lib/plist.js
@@ -238,7 +238,7 @@
    */
   exports.build = function(obj) {
     var XMLHDR = { 'version': '1.0','encoding': 'UTF-8'}
-        , XMLDTD = { 'ext': 'PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\"'}
+        , XMLDTD = { 'ext': 'PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\"'}
         , doc = xmlbuilder.create()
         , child = doc.begin('plist', XMLHDR, XMLDTD).att('version', '1.0');
 


### PR DESCRIPTION
Recent Apple docs are using:

```
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
```
