### PR TITLE
Fixed unescaped text being output

### DIFF
--- a/lib/plist.js
+++ b/lib/plist.js
@@ -290,7 +290,7 @@
         next_child.ele('data').raw(utf8_to_b64(next));
       } else {
       	// it's not base 64 encoded, assume it's a <string> node
-      	next_child.ele('string').raw(next);
+      	next_child.ele('string').text(next);
       }
     }
   };


### PR DESCRIPTION
Characters such as `<`, `>` and `&` weren't being replaced by their respective entities when building the PList document using `xmlbuilder`. I've changed it so that `<string>` items have their contents correctly escaped.
