### PR TITLE
Upgrade xmlbuilder dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "main": "lib/plist.js",
   "dependencies": {
     "base64-js": "0.0.6",
-    "xmlbuilder": "2.2.1",
+    "xmlbuilder": "2.6.x",
     "xmldom": "0.1.x",
     "util-deprecate": "1.0.0"
   },

--- a/test/build.js
+++ b/test/build.js
@@ -122,7 +122,7 @@ describe('plist', function () {
 <plist version="1.0">
   <dict>
     <key>a</key>
-    <string></string>
+    <string/>
   </dict>
 </plist>
 */}));


### PR DESCRIPTION
This removes extra `[WARN]` message while installing this module on node@0.12