### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,16 +25,16 @@
   ],
   "main": "lib/plist.js",
   "dependencies": {
-    "base64-js": "0.0.6",
-    "xmlbuilder": "2.2.1",
+    "base64-js": "0.0.8",
+    "xmlbuilder": "3.0.0",
     "xmldom": "0.1.x",
-    "util-deprecate": "1.0.0"
+    "util-deprecate": "1.0.1"
   },
   "devDependencies": {
-    "browserify": "5.10.1",
-    "mocha": "1.18.2",
-    "multiline": "0.3.4",
-    "zuul": "1.10.2"
+    "browserify": "11.1.0",
+    "mocha": "2.3.2",
+    "multiline": "1.0.2",
+    "zuul": "3.5.0"
   },
   "scripts": {
     "test": "make test"

--- a/test/build.js
+++ b/test/build.js
@@ -122,7 +122,7 @@ describe('plist', function () {
 <plist version="1.0">
   <dict>
     <key>a</key>
-    <string></string>
+    <string/>
   </dict>
 </plist>
 */}));


### PR DESCRIPTION
using newer versions of node, this warning comes up in npm:
`npm WARN engine xmlbuilder@2.2.1: wanted: {"node":"0.8.x || 0.10.x"} (current {"node":"0.12.7","npm":"2.11.3"})`