### PR TITLE
fix empty <key /> lead index out of bounds issue

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -31,6 +31,25 @@ function shouldIgnoreNode (node) {
     || node.nodeType === 4;  // cdata
 }
 
+/**
+ * Check if the node is empty. Some plist file has such node:
+ * <key />
+ * this node shoud be ignored.
+ *
+ * @see https://github.com/TooTallNate/plist.js/issues/66
+ * @param {Element} node
+ * @returns {Boolean}
+ * @api private
+ */
+function isEmptyNode(node){
+
+  if(!node.childNodes || node.childNodes.length == 0) {
+    return true;
+  } else {
+    return false;
+  }
+
+}
 
 /**
  * Parses a Plist XML string. Returns an Object.
@@ -129,7 +148,7 @@ function parsePlistXML (node) {
     key = null;
     for (i=0; i < node.childNodes.length; i++) {
       // ignore comment nodes (text)
-      if (!shouldIgnoreNode(node.childNodes[i])) {
+      if (!shouldIgnoreNode(node.childNodes[i]) && !isEmptyNode(node)) {
         if (key === null) {
           key = parsePlistXML(node.childNodes[i]);
         } else {


### PR DESCRIPTION
prevent 'index of bounds' issues from empty <key /> node.

see: https://github.com/TooTallNate/plist.js/issues/66
