### PR TITLE
Prevent Xcode errors

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -96,7 +96,10 @@ function parsePlistXML (node) {
       // ignore comment nodes (text)
       if (!shouldIgnoreNode(node.childNodes[i])) {
         if (key === null) {
-          key = parsePlistXML(node.childNodes[i]);
+          // key can be null if it's an empty node
+          if(node.childNodes[i].nodeName === 'key') {
+            key = parsePlistXML(node.childNodes[i]);
+          }
         } else {
           new_obj[key] = parsePlistXML(node.childNodes[i]);
           key = null;
@@ -128,7 +131,7 @@ function parsePlistXML (node) {
     return res;
   } else if (node.nodeName === 'string') {
     res = '';
-    if(isEmptyNode(node)) return null;
+    if(isEmptyNode(node)) return '';
     for (d=0; d < node.childNodes.length; d++) {
       res += node.childNodes[d].nodeValue;
     }

--- a/test/parse.js
+++ b/test/parse.js
@@ -72,6 +72,21 @@ describe('plist', function () {
       assert.ok(isEmpty(parsed));
     });
 
+    it('should parse an empty <string/> in a dictionary', function() {
+      var xml = multiline(function() {/*
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>foo</key>
+    <string/>
+  </dict>
+</plist>
+*/});
+      var parsed = parse(xml);
+      assert.deepEqual(parsed, {foo: ''});
+    });
+
     it('should parse an empty <key></key> in a dictionary', function() {
       var xml = multiline(function() {/*
 <?xml version="1.0" encoding="UTF-8"?>

--- a/test/parse.js
+++ b/test/parse.js
@@ -102,6 +102,23 @@ describe('plist', function () {
       assert.ok(isEmpty(parsed));
     });
 
+    it('should prevent errors when empty <key></key> in a dictionary', function() {
+      var xml = multiline(function() {/*
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key></key>
+    <string>should never be added</string>
+    <key>foo</key>
+    <string>bar</string>
+  </dict>
+</plist>
+*/});
+      var parsed = parse(xml);
+      assert.deepEqual(parsed, {foo: 'bar'});
+    });
+
     it('should parse an empty <key></key> and <string></string> in dictionary with more data', function() {
       var xml = multiline(function() {/*
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Hello,

Just a fix that ensures String values are never null in order to prevent XCode issues as described in #79.
Also, if a key is null it won't be added anymore to the parsed object. With the actual version, if
a key is null, its value is used as a key :/

Thanks !
