### PR TITLE
Harden test-cases and align with other implementations

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -43,6 +43,12 @@ function isEmptyNode(node){
   }
 }
 
+function invariant(test, message) {
+  if (!test) {
+    throw new Error(message);
+  }
+}
+
 /**
  * Parses a Plist XML string. Returns an Object.
  *
@@ -53,9 +59,10 @@ function isEmptyNode(node){
 
 function parse (xml) {
   var doc = new DOMParser().parseFromString(xml);
-  if (doc.documentElement.nodeName !== 'plist') {
-    throw new Error('malformed document. First element should be <plist>');
-  }
+  invariant(
+    doc.documentElement.nodeName === 'plist',
+    'malformed document. First element should be <plist>'
+  );
   var plist = parsePlistXML(doc.documentElement);
 
   // the root <plist> node gets interpreted as an Array,
@@ -74,17 +81,18 @@ function parse (xml) {
  */
 
 function parsePlistXML (node) {
-  var i, new_obj, key, val, new_arr, res, d;
+  var i, new_obj, key, val, new_arr, res, counter, type;
 
   if (!node)
     return null;
 
   if (node.nodeName === 'plist') {
     new_arr = [];
-    for (i=0; i < node.childNodes.length; i++) {
-      // ignore comment nodes (text)
-      if (!shouldIgnoreNode(node.childNodes[i])) {
-        new_arr.push( parsePlistXML(node.childNodes[i]));
+    if (!isEmptyNode(node)) {
+      for (i=0; i < node.childNodes.length; i++) {
+        if (!shouldIgnoreNode(node.childNodes[i])) {
+          new_arr.push( parsePlistXML(node.childNodes[i]));
+        }
       }
     }
     return new_arr;
@@ -92,26 +100,41 @@ function parsePlistXML (node) {
   } else if (node.nodeName === 'dict') {
     new_obj = {};
     key = null;
-    for (i=0; i < node.childNodes.length; i++) {
-      // ignore comment nodes (text)
-      if (!shouldIgnoreNode(node.childNodes[i])) {
-        if (key === null) {
+    counter = 0;
+    if (!isEmptyNode(node)) {
+      for (i=0; i < node.childNodes.length; i++) {
+        if (shouldIgnoreNode(node.childNodes[i])) continue;
+        if (counter % 2 === 0) {
+          invariant(
+            node.childNodes[i].nodeName === 'key',
+            'Missing key while parsing <dict/>.'
+          );
           key = parsePlistXML(node.childNodes[i]);
         } else {
+          invariant(
+            node.childNodes[i].nodeName !== 'key',
+            'Unexpected key "'
+              + parsePlistXML(node.childNodes[i])
+              + '" while parsing <dict/>.'
+          );
           new_obj[key] = parsePlistXML(node.childNodes[i]);
-          key = null;
         }
+        counter += 1;
       }
+    }
+    if (counter % 2 === 1) {
+      throw new Error('Missing value for "' + key + '" while parsing <dict/>');
     }
     return new_obj;
 
   } else if (node.nodeName === 'array') {
     new_arr = [];
-    for (i=0; i < node.childNodes.length; i++) {
-      // ignore comment nodes (text)
-      if (!shouldIgnoreNode(node.childNodes[i])) {
-        res = parsePlistXML(node.childNodes[i]);
-        if (null != res) new_arr.push(res);
+    if (!isEmptyNode(node)) {
+      for (i=0; i < node.childNodes.length; i++) {
+        if (!shouldIgnoreNode(node.childNodes[i])) {
+          res = parsePlistXML(node.childNodes[i]);
+          if (null != res) new_arr.push(res);
+        }
       }
     }
     return new_arr;
@@ -120,45 +143,59 @@ function parsePlistXML (node) {
     // TODO: what should we do with text types? (CDATA sections)
 
   } else if (node.nodeName === 'key') {
-    if(isEmptyNode(node)) return null;
     res = '';
-    if(node.childNodes[0]) {
+    if(!isEmptyNode(node)) {
       res = node.childNodes[0].nodeValue;
     }
     return res;
   } else if (node.nodeName === 'string') {
     res = '';
-    if(isEmptyNode(node)) return null;
-    for (d=0; d < node.childNodes.length; d++) {
-      res += node.childNodes[d].nodeValue;
+    if(!isEmptyNode(node)) {
+      for (i=0; i < node.childNodes.length; i++) {
+        var type = node.childNodes[i].nodeType;
+        if (type === 3 || type === 4) {
+          res += node.childNodes[i].nodeValue;
+        }
+      }
     }
     return res;
 
   } else if (node.nodeName === 'integer') {
-    // parse as base 10 integer
+    invariant(
+      !isEmptyNode(node),
+      'Cannot parse "" as integer.'
+    );
     return parseInt(node.childNodes[0].nodeValue, 10);
 
   } else if (node.nodeName === 'real') {
+    invariant(
+      !isEmptyNode(node),
+      'Cannot parse "" as real.'
+    );
     res = '';
-    for (d=0; d < node.childNodes.length; d++) {
-      if (node.childNodes[d].nodeType === 3) {
-        res += node.childNodes[d].nodeValue;
+    for (i=0; i < node.childNodes.length; i++) {
+      if (node.childNodes[i].nodeType === 3) {
+        res += node.childNodes[i].nodeValue;
       }
     }
     return parseFloat(res);
 
   } else if (node.nodeName === 'data') {
     res = '';
-    for (d=0; d < node.childNodes.length; d++) {
-      if (node.childNodes[d].nodeType === 3) {
-        res += node.childNodes[d].nodeValue.replace(/\s+/g, '');
+    if (!isEmptyNode(node)) {
+      for (i=0; i < node.childNodes.length; i++) {
+        if (node.childNodes[i].nodeType === 3) {
+          res += node.childNodes[i].nodeValue.replace(/\s+/g, '');
+        }
       }
     }
-
-    // decode base64 data to a Buffer instance
     return new Buffer(res, 'base64');
 
   } else if (node.nodeName === 'date') {
+    invariant(
+      !isEmptyNode(node),
+      'Cannot parse "" as Date.'
+    )
     return new Date(node.childNodes[0].nodeValue);
 
   } else if (node.nodeName === 'true') {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -10,6 +10,11 @@ var DOMParser = require('xmldom').DOMParser;
 
 exports.parse = parse;
 
+var TEXT_NODE = 3;
+var CDATA_NODE = 4;
+var COMMENT_NODE = 8;
+
+
 /**
  * We ignore raw text (usually whitespace), <!-- xml comments -->,
  * and raw CDATA nodes.
@@ -20,9 +25,9 @@ exports.parse = parse;
  */
 
 function shouldIgnoreNode (node) {
-  return node.nodeType === 3 // text
-    || node.nodeType === 8   // comment
-    || node.nodeType === 4;  // cdata
+  return node.nodeType === TEXT_NODE
+    || node.nodeType === COMMENT_NODE
+    || node.nodeType === CDATA_NODE;
 }
 
 /**
@@ -88,39 +93,40 @@ function parsePlistXML (node) {
 
   if (node.nodeName === 'plist') {
     new_arr = [];
-    if (!isEmptyNode(node)) {
-      for (i=0; i < node.childNodes.length; i++) {
-        if (!shouldIgnoreNode(node.childNodes[i])) {
-          new_arr.push( parsePlistXML(node.childNodes[i]));
-        }
+    if (isEmptyNode(node)) {
+      return new_arr;
+    }
+    for (i=0; i < node.childNodes.length; i++) {
+      if (!shouldIgnoreNode(node.childNodes[i])) {
+        new_arr.push( parsePlistXML(node.childNodes[i]));
       }
     }
     return new_arr;
-
   } else if (node.nodeName === 'dict') {
     new_obj = {};
     key = null;
     counter = 0;
-    if (!isEmptyNode(node)) {
-      for (i=0; i < node.childNodes.length; i++) {
-        if (shouldIgnoreNode(node.childNodes[i])) continue;
-        if (counter % 2 === 0) {
-          invariant(
-            node.childNodes[i].nodeName === 'key',
-            'Missing key while parsing <dict/>.'
-          );
-          key = parsePlistXML(node.childNodes[i]);
-        } else {
-          invariant(
-            node.childNodes[i].nodeName !== 'key',
-            'Unexpected key "'
-              + parsePlistXML(node.childNodes[i])
-              + '" while parsing <dict/>.'
-          );
-          new_obj[key] = parsePlistXML(node.childNodes[i]);
-        }
-        counter += 1;
+    if (isEmptyNode(node)) {
+      return new_obj;
+    }
+    for (i=0; i < node.childNodes.length; i++) {
+      if (shouldIgnoreNode(node.childNodes[i])) continue;
+      if (counter % 2 === 0) {
+        invariant(
+          node.childNodes[i].nodeName === 'key',
+          'Missing key while parsing <dict/>.'
+        );
+        key = parsePlistXML(node.childNodes[i]);
+      } else {
+        invariant(
+          node.childNodes[i].nodeName !== 'key',
+          'Unexpected key "'
+            + parsePlistXML(node.childNodes[i])
+            + '" while parsing <dict/>.'
+        );
+        new_obj[key] = parsePlistXML(node.childNodes[i]);
       }
+      counter += 1;
     }
     if (counter % 2 === 1) {
       throw new Error('Missing value for "' + key + '" while parsing <dict/>');
@@ -129,12 +135,13 @@ function parsePlistXML (node) {
 
   } else if (node.nodeName === 'array') {
     new_arr = [];
-    if (!isEmptyNode(node)) {
-      for (i=0; i < node.childNodes.length; i++) {
-        if (!shouldIgnoreNode(node.childNodes[i])) {
-          res = parsePlistXML(node.childNodes[i]);
-          if (null != res) new_arr.push(res);
-        }
+    if (isEmptyNode(node)) {
+      return new_arr;
+    }
+    for (i=0; i < node.childNodes.length; i++) {
+      if (!shouldIgnoreNode(node.childNodes[i])) {
+        res = parsePlistXML(node.childNodes[i]);
+        if (null != res) new_arr.push(res);
       }
     }
     return new_arr;
@@ -143,19 +150,19 @@ function parsePlistXML (node) {
     // TODO: what should we do with text types? (CDATA sections)
 
   } else if (node.nodeName === 'key') {
-    res = '';
-    if(!isEmptyNode(node)) {
-      res = node.childNodes[0].nodeValue;
+    if (isEmptyNode(node)) {
+      return '';
     }
-    return res;
+    return node.childNodes[0].nodeValue;
   } else if (node.nodeName === 'string') {
     res = '';
-    if(!isEmptyNode(node)) {
-      for (i=0; i < node.childNodes.length; i++) {
-        var type = node.childNodes[i].nodeType;
-        if (type === 3 || type === 4) {
-          res += node.childNodes[i].nodeValue;
-        }
+    if (isEmptyNode(node)) {
+      return res;
+    }
+    for (i=0; i < node.childNodes.length; i++) {
+      var type = node.childNodes[i].nodeType;
+      if (type === TEXT_NODE || type === CDATA_NODE) {
+        res += node.childNodes[i].nodeValue;
       }
     }
     return res;
@@ -174,7 +181,7 @@ function parsePlistXML (node) {
     );
     res = '';
     for (i=0; i < node.childNodes.length; i++) {
-      if (node.childNodes[i].nodeType === 3) {
+      if (node.childNodes[i].nodeType === TEXT_NODE) {
         res += node.childNodes[i].nodeValue;
       }
     }
@@ -182,11 +189,12 @@ function parsePlistXML (node) {
 
   } else if (node.nodeName === 'data') {
     res = '';
-    if (!isEmptyNode(node)) {
-      for (i=0; i < node.childNodes.length; i++) {
-        if (node.childNodes[i].nodeType === 3) {
-          res += node.childNodes[i].nodeValue.replace(/\s+/g, '');
-        }
+    if (isEmptyNode(node)) {
+      return new Buffer(res, 'base64');
+    }
+    for (i=0; i < node.childNodes.length; i++) {
+      if (node.childNodes[i].nodeType === TEXT_NODE) {
+        res += node.childNodes[i].nodeValue.replace(/\s+/g, '');
       }
     }
     return new Buffer(res, 'base64');

--- a/test/parse.js
+++ b/test/parse.js
@@ -3,208 +3,196 @@ var assert = require('assert');
 var parse = require('../').parse;
 var multiline = require('multiline');
 
-function isEmpty(o){
-  for(var i in o){
-    if(o.hasOwnProperty(i)){
-      return false;
-    }
-  }
-  return true;
+function parseFixture(string) {
+  var intro = multiline(function () {
+/*
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+*/
+  });
+  return parse(intro + string + '</plist>');
 }
 
-describe('plist', function () {
+describe('parse()', function () {
 
-  describe('parse()', function () {
-
-    it('should parse a minimal <string> node into a String', function () {
-      var parsed = parse('<plist><string>Hello World!</string></plist>');
-      assert.strictEqual(parsed, 'Hello World!');
+  describe('boolean', function () {
+    it('should parse a <true> node into a Boolean `true` value', function () {
+      var parsed = parseFixture('<true/>');
+      assert.strictEqual(parsed, true);
     });
 
-    it('should parse a full XML <string> node into a String', function () {
-      var xml = multiline(function () {/*
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<string>gray</string>
-</plist>
-*/});
-      var parsed = parse(xml);
-      assert.strictEqual(parsed, 'gray');
+    it('should parse a <false> node into a Boolean `false` value', function () {
+      var parsed = parseFixture('<false/>');
+      assert.strictEqual(parsed, false);
     });
+  });
 
-    it('should parse an <integer> node into a Number', function () {
-      var xml = multiline(function () {/*
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <integer>14</integer>
-</plist>
-*/});
-      var parsed = parse(xml);
-      assert.strictEqual(parsed, 14);
-    });
-
-    it('should parse a <real> node into a Number', function () {
-      var xml = multiline(function () {/*
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <real>3.14</real>
-</plist>
-*/});
-      var parsed = parse(xml);
-      assert.strictEqual(parsed, 3.14);
-    });
-
-    it('should parse an empty <key/> in a dictionary', function() {
-      var xml = multiline(function() {/*
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <dict>
-    <key />
-    <string />
-  </dict>
-</plist>
-*/});
-      var parsed = parse(xml);
-      assert.ok(isEmpty(parsed));
-    });
-
-    it('should parse an empty <key></key> in a dictionary', function() {
-      var xml = multiline(function() {/*
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <dict>
-    <key></key>
-    <string />
-  </dict>
-</plist>
-*/});
-      var parsed = parse(xml);
-      assert.ok(isEmpty(parsed));
-    });
-
-    it('should parse an empty <key></key> and <string></string> in dictionary with more data', function() {
-      var xml = multiline(function() {/*
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <dict>
-    <key></key>
-    <string></string>
-    <key>UIRequiredDeviceCapabilities</key>
-    <array>
-      <string>armv7</string>
-    </array>
-  </dict>
-</plist>
-*/});
-      var parsed = parse(xml);
-      assert.deepEqual(parsed, {
-        'UIRequiredDeviceCapabilities': [
-          'armv7'
-        ]
+  describe('integer', function () {
+    it('should throw an Error when parsing an empty integer', function () {
+      assert.throws(function () {
+        parseFixture('<integer/>');
       });
     });
 
-    it('should parse a <date> node into a Date', function () {
-      var xml = multiline(function () {/*
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <date>2010-02-08T21:41:23Z</date>
-</plist>
-*/});
-      var parsed = parse(xml);
-      assert(parsed instanceof Date);
-      assert.strictEqual(parsed.getTime(), 1265665283000);
+    it('should parse an <integer> node into a Number', function () {
+      var parsed = parseFixture('<integer>14</integer>');
+      assert.strictEqual(parsed, 14);
+    });
+  });
+
+  describe('real', function () {
+    it('should throw an Error when parsing an empty real', function () {
+      assert.throws(function () {
+        parseFixture('<real/>');
+      });
+    });
+
+    it('should parse a <real> node into a Number', function () {
+      var parsed = parseFixture('<real>3.14</real>');
+      assert.strictEqual(parsed, 3.14);
+    });
+  });
+
+  describe('string', function () {
+    it('should parse a self closing string', function () {
+      var parsed = parseFixture('<string/>');
+      assert.strictEqual(parsed, '');
+    });
+
+    it('should parse an empty string', function () {
+      var parsed = parseFixture('<string></string>');
+      assert.strictEqual(parsed, '');
+    });
+
+    it('should parse the string contents', function () {
+      var parsed = parseFixture('<string>test</string>');
+      assert.strictEqual(parsed, 'test');
+    });
+
+    it('should parse a string with comments', function () {
+      var parsed = parseFixture('<string>a<!-- comment --> string</string>');
+      assert.strictEqual(parsed, 'a string');
+    });
+  });
+
+  describe('data', function () {
+    it('should parse an empty data tag into an empty Buffer', function () {
+      var parsed = parseFixture('<data/>');
+      assert(Buffer.isBuffer(parsed));
+      assert.strictEqual(parsed.toString('utf-8'), '');
     });
 
     it('should parse a <data> node into a Buffer', function () {
-      var xml = multiline(function () {/*
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <data>4pyTIMOgIGxhIG1vZGU=</data>
-</plist>
-*/});
-      var parsed = parse(xml);
+      var parsed = parseFixture('<data>4pyTIMOgIGxhIG1vZGU=</data>');
       assert(Buffer.isBuffer(parsed));
       assert.strictEqual(parsed.toString('utf8'), '✓ à la mode');
     });
 
     it('should parse a <data> node with newlines into a Buffer', function () {
-      var xml = multiline(function () {/*
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <data>4pyTIMOgIGxhIG
+      var xml = multiline(function () {
+/*
+<data>4pyTIMOgIGxhIG
 
 
-  1v
+1v
 
-  ZG
-  U=</data>
-</plist>
-*/});
-      var parsed = parse(xml);
+ZG
+U=</data>
+*/
+      });
+      var parsed = parseFixture(xml);
       assert(Buffer.isBuffer(parsed));
       assert.strictEqual(parsed.toString('utf8'), '✓ à la mode');
     });
+  });
 
-    it('should parse a <true> node into a Boolean `true` value', function () {
-      var xml = multiline(function () {/*
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <true/>
-</plist>
-*/});
-      var parsed = parse(xml);
-      assert.strictEqual(parsed, true);
+  describe('date', function () {
+    it('should throw an error when parsing an empty date', function () {
+      assert.throws(function () {
+        parseFixture('<date/>')
+      });
     });
 
-    it('should parse a <false> node into a Boolean `false` value', function () {
-      var xml = multiline(function () {/*
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <false/>
-</plist>
-*/});
-      var parsed = parse(xml);
-      assert.strictEqual(parsed, false);
+    it('should parse a <date> node into a Date', function () {
+      var parsed = parseFixture('<date>2010-02-08T21:41:23Z</date>');
+      assert(parsed instanceof Date);
+      assert.strictEqual(parsed.getTime(), 1265665283000);
+    });
+  });
+
+  describe('array', function () {
+    it('should parse an empty array', function () {
+      var parsed = parseFixture('<array/>');
+      assert.deepEqual(parsed, []);
     });
 
-    it('should parse an <array> node into an Array', function () {
-      var xml = multiline(function () {/*
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <array>
-    <dict>
-      <key>duration</key>
-      <real>5555.0495000000001</real>
-      <key>start</key>
-      <real>0.0</real>
-    </dict>
-  </array>
-</plist>
-*/});
-      var parsed = parse(xml);
-      assert.deepEqual(parsed, [
-        {
-          duration: 5555.0495,
-          start: 0
-        }
-      ]);
+    it('should parse an array with one element', function () {
+      var parsed = parseFixture('<array><true/></array>');
+      assert.deepEqual(parsed, [true]);
     });
 
+    it('should parse an array with multiple elements', function () {
+      var parsed = parseFixture(
+        '<array><string>1</string><string>2</string></array>'
+      );
+      assert.deepEqual(parsed, ['1', '2']);
+    });
+
+    it('should parse empty elements inside an array', function () {
+      var parsed = parseFixture('<array><string/><false/></array>');
+      assert.deepEqual(parsed, ['', false]);
+    });
+  });
+
+  describe('dict', function () {
+    it('should throw if key is missing', function () {
+      assert.throws(function () {
+        parseFixture('<dict><string>x</string></dict>');
+      });
+    });
+
+    it('should throw if two keys follow each other', function () {
+      assert.throws(function () {
+        parseFixture('<dict><key>a</key><key>b</key></dict>');
+      });
+    });
+
+    it('should throw if value is missing', function () {
+      assert.throws(function () {
+        parseFixture('<dict><key>a</key></dict>');
+      });
+    });
+
+    it('should parse an empty key', function () {
+      var parsed = parseFixture('<dict><key/><string>1</string></dict>');
+      assert.deepEqual(parsed, { '': '1' });
+    });
+
+    it('should parse an empty value', function () {
+      var parsed = parseFixture('<dict><key>a</key><string/></dict>');
+      assert.deepEqual(parsed, { 'a': '' });
+    });
+
+    it('should parse multiple key/value pairs', function () {
+      var parsed = parseFixture(
+        '<dict><key>a</key><true/><key>b</key><false/></dict>'
+      );
+      assert.deepEqual(parsed, { a: true, b: false });
+    });
+
+    it('should parse nested data structures', function () {
+      var parsed = parseFixture(
+        '<dict><key>a</key><dict><key>a1</key><true/></dict></dict>'
+      );
+      assert.deepEqual(parsed, { a: { a1: true } });
+    });
+  });
+
+  describe('integration', function () {
     it('should parse a plist file with XML comments', function () {
-      var xml = multiline(function () {/*
+      var xml = multiline(function () {
+/*
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -229,7 +217,8 @@ describe('plist', function () {
     <string>9.0</string>
   </dict>
 </plist>
-*/});
+*/
+      });
       var parsed = parse(xml);
       assert.deepEqual(parsed, {
         CFBundleName: 'Emacs',
@@ -241,7 +230,8 @@ describe('plist', function () {
     });
 
     it('should parse a plist file with CDATA content', function () {
-      var xml = multiline(function () {/*
+      var xml = multiline(function () {
+/*
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -287,7 +277,8 @@ int main(int argc, char *argv[])
 	</dict>
 </dict>
 </plist>
-*/});
+*/
+      });
       var parsed = parse(xml);
       assert.deepEqual(parsed, { OptionsLabel: 'Product',
         PopupMenu:
@@ -301,7 +292,8 @@ int main(int argc, char *argv[])
     });
 
     it('should parse an example "Cordova.plist" file', function () {
-      var xml = multiline(function () {/*
+      var xml = multiline(function () {
+/*
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!--
@@ -389,7 +381,8 @@ int main(int argc, char *argv[])
   </dict>
 </dict>
 </plist>
-*/});
+*/
+      });
       var parsed = parse(xml);
       assert.deepEqual(parsed, {
         UIWebViewBounce: true,
@@ -426,7 +419,8 @@ int main(int argc, char *argv[])
     });
 
     it('should parse an example "Xcode-Info.plist" file', function () {
-      var xml = multiline(function () {/*
+      var xml = multiline(function () {
+/*
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -476,7 +470,8 @@ int main(int argc, char *argv[])
 	<true/>
 </dict>
 </plist>
-*/});
+*/
+      });
       var parsed = parse(xml);
       assert.deepEqual(parsed, {
         CFBundleDevelopmentRegion: 'en',
@@ -504,7 +499,5 @@ int main(int argc, char *argv[])
         CFBundleAllowMixedLocalizations: true
       });
     });
-
   });
-
 });


### PR DESCRIPTION
This commit refactors and adds more tests to the `parse()` implementation
to align with similar libraries's behaviour, e.g.:
- https://github.com/Microsoft/node-fast-plist
- https://docs.python.org/3/library/plistlib.html

When running the new test suite against the old `lib/parse.js` implementation
a few tests were failing:
```
31 passing (177ms)
10 failing

1) parse() real should throw an Error when parsing an empty real:
    AssertionError: Missing expected exception..

2) parse() string should parse a self closing string:
    AssertionError: null === ''

3) parse() string should parse an empty string:
    AssertionError: null === ''

4) parse() string should parse a string with comments:
    AssertionError: 'a comment  string' === 'a string'

5) parse() array should parse empty elements inside an array:
    AssertionError: [ false ] deepEqual [ '', false ]

6) parse() dict should throw if key is missing:
    AssertionError: Missing expected exception..

7) parse() dict should throw if two keys follow each other:
    AssertionError: Missing expected exception..

8) parse() dict should throw if value is missing:
    AssertionError: Missing expected exception..

9) parse() dict should parse an empty key:
    AssertionError: {} deepEqual { '': '1' }

10) parse() dict should parse an empty value:
    AssertionError: { a: null } deepEqual { a: '' }
```

When executing the new implementation of `lib/parse.js` agains the old
tests the following tests were failing:
```
25 passing (143ms)
3 failing

1) plist parse() should parse an empty <key/> in a dictionary:
    AssertionError: false == true

2) plist parse() should parse an empty <key></key> in a dictionary:
    AssertionError: false == true

3) plist parse() should parse an empty <key></key> and <string></string> in dictionary with more data:
    AssertionError: { '': '', UIRequiredDeviceCapabilities: [ 'armv7' ] } deepEqual { UIRequiredDeviceCapabilities: [ 'armv7' ] }
```

As the output above shows, most of the issue are with the handling of
empty strings and empty dictionary keys.
Added with the new implementation are custom Errors for invalid
input, better handling of comments inside tags and a more aligned
handling of empty keys/strings.


I know this is a huge change, so I'd understand if you're hesitant to merge this,
but let me know your thoughts.
Initially I only wanted to fix the handling of empty strings/keys but then I got a bit carried away.

Related issues: #79 #71 #66 #81 #80 #67 