### PR TITLE
Add support for signed Plist files

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -63,7 +63,8 @@ function invariant(test, message) {
  */
 
 function parse (xml) {
-  var doc = new DOMParser().parseFromString(xml);
+  var extracted = extractPlist(xml);
+  var doc = new DOMParser().parseFromString(extracted);
   invariant(
     doc.documentElement.nodeName === 'plist',
     'malformed document. First element should be <plist>'
@@ -75,6 +76,22 @@ function parse (xml) {
   if (plist.length == 1) plist = plist[0];
 
   return plist;
+}
+
+/**
+ * Extract only the Plist string from a potentially signed string containing Plist-encoded data.
+ * @param {String} plist - the Plist String to extract from
+ * @returns {String} extracted Plist string
+ * @api private
+ */
+
+function extractPlist(plist) {
+  var plistStart = plist.indexOf("<plist"), plistEnd = plist.indexOf("</plist>");
+  
+  // Fallback to provided data if we can't find start and end, or, if somehow end precedes start.
+  if (plistStart < 0 || plistEnd < 0 || plistStart > plistEnd) return plist;
+
+  return plist.substring(plistStart, plistEnd + 8);
 }
 
 /**


### PR DESCRIPTION
Prior to this PR, plist files that were signed (such as the ones Apple provides as part of the MDM profile service response), would not work with plist.js.

This PR fixes that by checking for the starts and ends of the `<plist>` objects before feeding it into the XML parser. If it somehow can't find those tags, it falls back to the default behaviour, ensuring this change doesn't break any plist files.