### PR TITLE
Prevent invalid property list files

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -105,7 +105,7 @@ function walk_obj(next, next_child) {
   } else if ('Object' == name) {
     next_child = next_child.ele('dict');
     for (prop in next) {
-      if (next.hasOwnProperty(prop)) {
+      if (next.hasOwnProperty(prop) && Object.values(next).some(next => next || typeof next === 'string')) {
         next_child.ele('key').txt(prop);
         walk_obj(next[prop], next_child);
       }

--- a/test/build.js
+++ b/test/build.js
@@ -128,15 +128,13 @@ describe('plist', function () {
 */}));
     });
 
-    it('should omit undefined values', function () {
+    it('should discard keys when value is invalid', function () {
       var xml = build({ a: undefined });
       assert.strictEqual(xml, multiline(function () {/*
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>a</key>
-  </dict>
+  <dict/>
 </plist>
 */}));
     });


### PR DESCRIPTION
This pull request prevents invalid property list files from being created by discarding invalid key/value pairs. Previously keys could be added without values leading to invalid files:

```
echo '<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
 <dict>
   <key>a</key>
 </dict>
</plist>' | plutil -
```
`<stdin>: Value missing for key inside <dict> at line 6`