### PR TITLE
Fix Buffer deprecation warning

### DIFF
--- a/test/build.js
+++ b/test/build.js
@@ -52,7 +52,7 @@ describe('plist', function () {
     });
 
     it('should create a plist XML date from a Buffer', function () {
-      var xml = build(new Buffer('☃'));
+      var xml = build(new Buffer.from('☃'));
       assert.strictEqual(xml, multiline(function () {/*
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">


### PR DESCRIPTION
This pull request fixes a deprecation warning related to the `Buffer` object when running tests:
```
[DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```