### PR TITLE
update xmldom dependency to MIT licensed version

### DIFF
--- a/dist/plist-parse.js
+++ b/dist/plist-parse.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-var DOMParser = require('xmldom').DOMParser;
+var DOMParser = require('xmldom-alpha').DOMParser;
 
 /**
  * Module exports.

--- a/dist/plist.js
+++ b/dist/plist.js
@@ -160,7 +160,7 @@ function walk_obj(next, next_child) {
  * Module dependencies.
  */
 
-var DOMParser = require('xmldom').DOMParser;
+var DOMParser = require('xmldom-alpha').DOMParser;
 
 /**
  * Module exports.

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 
-var DOMParser = require('xmldom').DOMParser;
+var DOMParser = require('xmldom-alpha').DOMParser;
 
 /**
  * Module exports.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "plist",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16,8 +16,8 @@
       "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
       "dev": true,
       "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
       }
     },
     "abbrev": {
@@ -32,7 +32,7 @@
       "integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.18",
+        "mime-types": "~2.1.6",
         "negotiator": "0.5.3"
       }
     },
@@ -48,8 +48,8 @@
       "integrity": "sha512-efP54n3d1aLfjL2UMdaXa6DsswwzJeI5rqhbFvXMrKiJ6eJFpf+7R0zN7t8IC+XKn2YOAFAv6xbBNgHUkoHWLw==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3",
-        "xtend": "4.0.1"
+        "acorn": "^5.4.1",
+        "xtend": "^4.0.1"
       },
       "dependencies": {
         "acorn": {
@@ -71,10 +71,11 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -89,8 +90,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       }
     },
     "archiver": {
@@ -99,11 +100,11 @@
       "integrity": "sha1-zxUteU+Gu9k/mFjaYNNqrqutm78=",
       "dev": true,
       "requires": {
-        "file-utils": "0.1.5",
-        "lazystream": "0.1.0",
-        "lodash": "2.4.2",
-        "readable-stream": "1.0.34",
-        "zip-stream": "0.2.3"
+        "file-utils": "~0.1.5",
+        "lazystream": "~0.1.0",
+        "lodash": "~2.4.1",
+        "readable-stream": "~1.0.24",
+        "zip-stream": "~0.2.0"
       },
       "dependencies": {
         "isarray": {
@@ -124,10 +125,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -144,7 +145,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -153,7 +154,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -210,9 +211,9 @@
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert": {
@@ -236,7 +237,7 @@
       "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "^4.0.3"
       }
     },
     "async": {
@@ -257,7 +258,7 @@
       "integrity": "sha1-GCEOAZeL/cugQ5VUl6XNMVwKakE=",
       "dev": true,
       "requires": {
-        "runnel": "0.5.3"
+        "runnel": "~0.5.0"
       }
     },
     "aws-sign2": {
@@ -295,7 +296,7 @@
       "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.0.34"
+        "readable-stream": "~1.0.26"
       },
       "dependencies": {
         "isarray": {
@@ -310,10 +311,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -337,14 +338,14 @@
       "dev": true,
       "requires": {
         "bytes": "1.0.0",
-        "content-type": "1.0.4",
-        "debug": "2.2.0",
-        "depd": "1.0.1",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
         "iconv-lite": "0.4.8",
-        "on-finished": "2.2.1",
+        "on-finished": "~2.2.1",
         "qs": "2.4.2",
-        "raw-body": "2.0.2",
-        "type-is": "1.6.16"
+        "raw-body": "~2.0.1",
+        "type-is": "~1.6.2"
       },
       "dependencies": {
         "bytes": {
@@ -406,7 +407,7 @@
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
       "dev": true,
       "requires": {
-        "hoek": "0.9.1"
+        "hoek": "0.9.x"
       }
     },
     "brace-expansion": {
@@ -415,7 +416,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -425,9 +426,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "brorand": {
@@ -442,12 +443,12 @@
       "integrity": "sha512-Q4Rvn7P6ObyWfc4stqLWHtG1MJ8vVtjgT24Zbu+8UTzxYuZouqZsmNRRTFVMY/Ux0eIKv1d+JWzsInTX+fdHPQ==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
-        "combine-source-map": "0.8.0",
-        "defined": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "through2": "2.0.3",
-        "umd": "3.0.3"
+        "JSONStream": "^1.0.3",
+        "combine-source-map": "~0.8.0",
+        "defined": "^1.0.0",
+        "safe-buffer": "^5.1.1",
+        "through2": "^2.0.0",
+        "umd": "^3.0.0"
       }
     },
     "browser-resolve": {
@@ -473,54 +474,54 @@
       "integrity": "sha512-iSH21jK0+IApV8YHOfmGt1qsGd74oflQ1Ko/28JOkWLFNBngAQfKb6WYIJ9CufH8vycqKX1sYU3y7ZrVhwevAg==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
-        "assert": "1.4.1",
-        "browser-pack": "6.0.4",
-        "browser-resolve": "1.11.2",
-        "browserify-zlib": "0.2.0",
-        "buffer": "5.1.0",
-        "cached-path-relative": "1.0.1",
-        "concat-stream": "1.6.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "defined": "1.0.0",
-        "deps-sort": "2.0.0",
-        "domain-browser": "1.2.0",
-        "duplexer2": "0.1.4",
-        "events": "2.0.0",
-        "glob": "7.1.2",
-        "has": "1.0.1",
-        "htmlescape": "1.1.1",
-        "https-browserify": "1.0.0",
-        "inherits": "2.0.3",
-        "insert-module-globals": "7.0.2",
-        "labeled-stream-splicer": "2.0.0",
-        "mkdirp": "0.5.1",
-        "module-deps": "6.0.0",
-        "os-browserify": "0.3.0",
-        "parents": "1.0.1",
-        "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "read-only-stream": "2.0.0",
-        "readable-stream": "2.3.5",
-        "resolve": "1.5.0",
-        "shasum": "1.0.2",
-        "shell-quote": "1.6.1",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.8.1",
-        "string_decoder": "1.0.3",
-        "subarg": "1.0.0",
-        "syntax-error": "1.4.0",
-        "through2": "2.0.3",
-        "timers-browserify": "1.4.2",
+        "JSONStream": "^1.0.3",
+        "assert": "^1.4.0",
+        "browser-pack": "^6.0.1",
+        "browser-resolve": "^1.11.0",
+        "browserify-zlib": "~0.2.0",
+        "buffer": "^5.0.2",
+        "cached-path-relative": "^1.0.0",
+        "concat-stream": "^1.6.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "~1.0.0",
+        "crypto-browserify": "^3.0.0",
+        "defined": "^1.0.0",
+        "deps-sort": "^2.0.0",
+        "domain-browser": "^1.2.0",
+        "duplexer2": "~0.1.2",
+        "events": "^2.0.0",
+        "glob": "^7.1.0",
+        "has": "^1.0.0",
+        "htmlescape": "^1.1.0",
+        "https-browserify": "^1.0.0",
+        "inherits": "~2.0.1",
+        "insert-module-globals": "^7.0.0",
+        "labeled-stream-splicer": "^2.0.0",
+        "mkdirp": "^0.5.0",
+        "module-deps": "^6.0.0",
+        "os-browserify": "~0.3.0",
+        "parents": "^1.0.1",
+        "path-browserify": "~0.0.0",
+        "process": "~0.11.0",
+        "punycode": "^1.3.2",
+        "querystring-es3": "~0.2.0",
+        "read-only-stream": "^2.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.1.4",
+        "shasum": "^1.0.0",
+        "shell-quote": "^1.6.1",
+        "stream-browserify": "^2.0.0",
+        "stream-http": "^2.0.0",
+        "string_decoder": "~1.0.0",
+        "subarg": "^1.0.0",
+        "syntax-error": "^1.1.1",
+        "through2": "^2.0.0",
+        "timers-browserify": "^1.0.1",
         "tty-browserify": "0.0.1",
-        "url": "0.11.0",
-        "util": "0.10.3",
-        "vm-browserify": "0.0.4",
-        "xtend": "4.0.1"
+        "url": "~0.11.0",
+        "util": "~0.10.1",
+        "vm-browserify": "~0.0.1",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "concat-stream": {
@@ -529,9 +530,9 @@
           "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.5",
-            "typedarray": "0.0.6"
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         },
         "detective": {
@@ -540,9 +541,9 @@
           "integrity": "sha512-TFHMqfOvxlgrfVzTEkNBSh9SvSNX/HfF4OFI2QFGCyPm02EsyILqnUeb5P6q7JZ3SFNTBL5t2sePRgrN4epUWQ==",
           "dev": true,
           "requires": {
-            "acorn-node": "1.3.0",
-            "defined": "1.0.0",
-            "minimist": "1.2.0"
+            "acorn-node": "^1.3.0",
+            "defined": "^1.0.0",
+            "minimist": "^1.1.1"
           }
         },
         "domain-browser": {
@@ -563,21 +564,21 @@
           "integrity": "sha512-BKsMhJJENEM4dTgqq2MDTTHXRHcNUFegoAwlG4HO4VMdUyMcJDKgfgI+MOv6tR5Iv8G3MKZFgsSiyP3ZoosRMw==",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.2",
-            "browser-resolve": "1.11.2",
-            "cached-path-relative": "1.0.1",
-            "concat-stream": "1.6.1",
-            "defined": "1.0.0",
-            "detective": "5.1.0",
-            "duplexer2": "0.1.4",
-            "inherits": "2.0.3",
-            "parents": "1.0.1",
-            "readable-stream": "2.3.5",
-            "resolve": "1.5.0",
-            "stream-combiner2": "1.1.1",
-            "subarg": "1.0.0",
-            "through2": "2.0.3",
-            "xtend": "4.0.1"
+            "JSONStream": "^1.0.3",
+            "browser-resolve": "^1.7.0",
+            "cached-path-relative": "^1.0.0",
+            "concat-stream": "~1.6.0",
+            "defined": "^1.0.0",
+            "detective": "^5.0.2",
+            "duplexer2": "^0.1.2",
+            "inherits": "^2.0.1",
+            "parents": "^1.0.0",
+            "readable-stream": "^2.0.2",
+            "resolve": "^1.4.0",
+            "stream-combiner2": "^1.1.1",
+            "subarg": "^1.0.0",
+            "through2": "^2.0.0",
+            "xtend": "^4.0.0"
           }
         }
       }
@@ -588,12 +589,12 @@
       "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
       "dev": true,
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cipher": {
@@ -602,9 +603,9 @@
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.1.1",
-        "browserify-des": "1.0.0",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -613,9 +614,9 @@
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "browserify-istanbul": {
@@ -624,9 +625,9 @@
       "integrity": "sha1-AcjjHWo1juUVD0Mhw/KJlalkw58=",
       "dev": true,
       "requires": {
-        "istanbul": "0.2.16",
-        "minimatch": "0.2.14",
-        "through": "2.3.8"
+        "istanbul": "^0.2.8",
+        "minimatch": "^0.2.14",
+        "through": "^2.3.4"
       },
       "dependencies": {
         "minimatch": {
@@ -635,8 +636,8 @@
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         }
       }
@@ -647,8 +648,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sign": {
@@ -657,13 +658,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.0"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "browserify-zlib": {
@@ -672,7 +673,7 @@
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "1.0.6"
+        "pako": "~1.0.5"
       }
     },
     "buffer": {
@@ -681,8 +682,8 @@
       "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
       "dev": true,
       "requires": {
-        "base64-js": "1.2.3",
-        "ieee754": "1.1.10"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-crc32": {
@@ -735,8 +736,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "char-split": {
@@ -762,15 +763,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.3",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       }
     },
     "cipher-base": {
@@ -779,8 +780,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "cliui": {
@@ -790,8 +791,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -816,10 +817,10 @@
       "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
       "dev": true,
       "requires": {
-        "convert-source-map": "1.1.3",
-        "inline-source-map": "0.6.2",
-        "lodash.memoize": "3.0.4",
-        "source-map": "0.5.7"
+        "convert-source-map": "~1.1.0",
+        "inline-source-map": "~0.6.0",
+        "lodash.memoize": "~3.0.3",
+        "source-map": "~0.5.3"
       }
     },
     "combined-stream": {
@@ -837,10 +838,10 @@
       "integrity": "sha1-Qi2SdDDAGr0GzUVbbfwEy0z4ADw=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "0.2.1",
-        "crc32-stream": "0.3.4",
-        "node-int64": "0.3.3",
-        "readable-stream": "1.0.34"
+        "buffer-crc32": "~0.2.1",
+        "crc32-stream": "~0.3.1",
+        "node-int64": "~0.3.0",
+        "readable-stream": "~1.0.26"
       },
       "dependencies": {
         "isarray": {
@@ -855,10 +856,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -875,7 +876,7 @@
       "integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
       "dev": true,
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": ">= 1.33.0 < 2"
       }
     },
     "compression": {
@@ -884,12 +885,12 @@
       "integrity": "sha1-zMGlR4jaGzrXcpxJ9qALOsmt9H8=",
       "dev": true,
       "requires": {
-        "accepts": "1.2.13",
+        "accepts": "~1.2.9",
         "bytes": "2.1.0",
-        "compressible": "2.0.13",
-        "debug": "2.2.0",
-        "on-headers": "1.0.1",
-        "vary": "1.0.1"
+        "compressible": "~2.0.3",
+        "debug": "~2.2.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -921,9 +922,9 @@
       "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.0.6",
-        "typedarray": "0.0.6"
+        "inherits": "~2.0.1",
+        "readable-stream": "~2.0.0",
+        "typedarray": "~0.0.5"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -938,12 +939,12 @@
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -965,7 +966,7 @@
         "bytes": "0.2.1",
         "cookie": "0.1.0",
         "cookie-signature": "1.0.1",
-        "debug": "0.8.1",
+        "debug": ">= 0.7.3 < 1",
         "fresh": "0.2.0",
         "methods": "0.1.0",
         "multiparty": "2.2.0",
@@ -1003,7 +1004,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "constants-browserify": {
@@ -1060,8 +1061,8 @@
       "integrity": "sha1-c7wltF+sHbZjIjGnv86JJ+nwZVI=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "0.2.1",
-        "readable-stream": "1.0.34"
+        "buffer-crc32": "~0.2.1",
+        "readable-stream": "~1.0.24"
       },
       "dependencies": {
         "isarray": {
@@ -1076,10 +1077,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -1096,8 +1097,8 @@
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-hash": {
@@ -1106,10 +1107,10 @@
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "sha.js": "2.4.10"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -1118,12 +1119,12 @@
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.10"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "cryptiles": {
@@ -1132,7 +1133,7 @@
       "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
       "dev": true,
       "requires": {
-        "boom": "0.4.2"
+        "boom": "0.4.x"
       }
     },
     "crypto-browserify": {
@@ -1141,17 +1142,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "1.0.0",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.0",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "diffie-hellman": "5.0.2",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.14",
-        "public-encrypt": "4.0.0",
-        "randombytes": "2.0.6",
-        "randomfill": "1.0.4"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "ctype": {
@@ -1212,10 +1213,10 @@
       "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
-        "shasum": "1.0.2",
-        "subarg": "1.0.0",
-        "through2": "2.0.3"
+        "JSONStream": "^1.0.3",
+        "shasum": "^1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0"
       }
     },
     "des.js": {
@@ -1224,8 +1225,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "destroy": {
@@ -1240,8 +1241,8 @@
       "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3",
-        "defined": "1.0.0"
+        "acorn": "^5.2.1",
+        "defined": "^1.0.0"
       },
       "dependencies": {
         "acorn": {
@@ -1258,9 +1259,9 @@
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "domain-browser": {
@@ -1275,7 +1276,7 @@
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.5"
+        "readable-stream": "^2.0.2"
       }
     },
     "ee-first": {
@@ -1290,13 +1291,13 @@
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.3",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "emitter-component": {
@@ -1317,7 +1318,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "escape-html": {
@@ -1338,10 +1339,10 @@
       "integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
       "dev": true,
       "requires": {
-        "esprima": "1.1.1",
-        "estraverse": "1.5.1",
-        "esutils": "1.0.0",
-        "source-map": "0.1.43"
+        "esprima": "~1.1.1",
+        "estraverse": "~1.5.0",
+        "esutils": "~1.0.0",
+        "source-map": "~0.1.33"
       },
       "dependencies": {
         "esprima": {
@@ -1357,7 +1358,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -1404,8 +1405,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.1"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "expand-brackets": {
@@ -1414,7 +1415,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -1423,7 +1424,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "express": {
@@ -1437,7 +1438,7 @@
         "connect": "2.12.0",
         "cookie": "0.1.0",
         "cookie-signature": "1.0.1",
-        "debug": "0.8.1",
+        "debug": ">= 0.7.3 < 1",
         "fresh": "0.2.0",
         "merge-descriptors": "0.0.1",
         "methods": "0.1.0",
@@ -1452,7 +1453,7 @@
           "integrity": "sha1-io8w7GcKb91kr1LxkUuQfXnq1bU=",
           "dev": true,
           "requires": {
-            "keypress": "0.1.0"
+            "keypress": "0.1.x"
           }
         },
         "debug": {
@@ -1481,7 +1482,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "fast-levenshtein": {
@@ -1496,13 +1497,13 @@
       "integrity": "sha1-3IFTyFU4fLTaywoXJVMfpESmtIw=",
       "dev": true,
       "requires": {
-        "findup-sync": "0.1.3",
-        "glob": "3.2.11",
-        "iconv-lite": "0.2.11",
-        "isbinaryfile": "0.1.9",
-        "lodash": "2.1.0",
-        "minimatch": "0.2.14",
-        "rimraf": "2.2.8"
+        "findup-sync": "~0.1.2",
+        "glob": "~3.2.6",
+        "iconv-lite": "~0.2.11",
+        "isbinaryfile": "~0.1.9",
+        "lodash": "~2.1.0",
+        "minimatch": "~0.2.12",
+        "rimraf": "~2.2.2"
       },
       "dependencies": {
         "glob": {
@@ -1511,8 +1512,8 @@
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "minimatch": "0.3.0"
+            "inherits": "2",
+            "minimatch": "0.3"
           },
           "dependencies": {
             "minimatch": {
@@ -1521,8 +1522,8 @@
               "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
               "dev": true,
               "requires": {
-                "lru-cache": "2.7.3",
-                "sigmund": "1.0.1"
+                "lru-cache": "2",
+                "sigmund": "~1.0.0"
               }
             }
           }
@@ -1539,8 +1540,8 @@
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         }
       }
@@ -1557,8 +1558,8 @@
       "integrity": "sha1-UGuRqTluqn4y+0KoQHfHoMc2t0E=",
       "dev": true,
       "requires": {
-        "glob": "3.2.11",
-        "minimatch": "0.4.0"
+        "glob": "3.x",
+        "minimatch": "0.x"
       },
       "dependencies": {
         "glob": {
@@ -1567,8 +1568,8 @@
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "minimatch": "0.3.0"
+            "inherits": "2",
+            "minimatch": "0.3"
           },
           "dependencies": {
             "minimatch": {
@@ -1577,8 +1578,8 @@
               "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
               "dev": true,
               "requires": {
-                "lru-cache": "2.7.3",
-                "sigmund": "1.0.1"
+                "lru-cache": "2",
+                "sigmund": "~1.0.0"
               }
             }
           }
@@ -1589,8 +1590,8 @@
           "integrity": "sha1-vSx9Bg0sjI/Xzefx8u0tWycP2xs=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         }
       }
@@ -1601,11 +1602,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "finalhandler": {
@@ -1615,12 +1616,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.4.0",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1661,8 +1662,8 @@
       "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
       "dev": true,
       "requires": {
-        "glob": "3.2.11",
-        "lodash": "2.4.2"
+        "glob": "~3.2.9",
+        "lodash": "~2.4.1"
       },
       "dependencies": {
         "glob": {
@@ -1671,8 +1672,8 @@
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "minimatch": "0.3.0"
+            "inherits": "2",
+            "minimatch": "0.3"
           }
         },
         "lodash": {
@@ -1687,8 +1688,8 @@
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         }
       }
@@ -1699,14 +1700,14 @@
       "integrity": "sha1-/kavwu1qlvYsXDvURvoln2AUqQk=",
       "dev": true,
       "requires": {
-        "adm-zip": "0.4.7",
-        "archiver": "0.7.1",
-        "async": "0.2.10",
-        "fs-extra": "0.8.1",
-        "lazystream": "0.1.0",
-        "node-uuid": "1.4.8",
-        "wrench": "1.5.9",
-        "xml2js": "0.4.19"
+        "adm-zip": "~0.4.3",
+        "archiver": "~0.7.1",
+        "async": "~0.2.9",
+        "fs-extra": "~0.8.1",
+        "lazystream": "~0.1.0",
+        "node-uuid": "~1.4.1",
+        "wrench": "~1.5.1",
+        "xml2js": "~0.4.0"
       },
       "dependencies": {
         "async": {
@@ -1729,7 +1730,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "forEachAsync": {
@@ -1738,7 +1739,7 @@
       "integrity": "sha1-43I/AJA5EOHrSx2zrVG1xkoxn+w=",
       "dev": true,
       "requires": {
-        "sequence": "2.2.1"
+        "sequence": "2.x"
       }
     },
     "foreach-shim": {
@@ -1759,9 +1760,9 @@
       "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
       "dev": true,
       "requires": {
-        "async": "0.9.2",
-        "combined-stream": "0.0.7",
-        "mime": "1.2.11"
+        "async": "~0.9.0",
+        "combined-stream": "~0.0.4",
+        "mime": "~1.2.11"
       }
     },
     "formidable": {
@@ -1788,10 +1789,10 @@
       "integrity": "sha1-Dld5/7/t9RG8dVWVx/A8BtS0Po0=",
       "dev": true,
       "requires": {
-        "jsonfile": "1.1.1",
-        "mkdirp": "0.3.5",
-        "ncp": "0.4.2",
-        "rimraf": "2.2.8"
+        "jsonfile": "~1.1.0",
+        "mkdirp": "0.3.x",
+        "ncp": "~0.4.2",
+        "rimraf": "~2.2.0"
       },
       "dependencies": {
         "mkdirp": {
@@ -1815,8 +1816,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.10.0",
-        "node-pre-gyp": "0.6.39"
+        "nan": "^2.3.0",
+        "node-pre-gyp": "^0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -1831,14 +1832,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.1.1",
@@ -1852,8 +1854,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "asn1": {
@@ -1889,7 +1891,8 @@
         "balanced-match": {
           "version": "0.4.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
@@ -1897,38 +1900,42 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           }
         },
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "~2.0.0"
           }
         },
         "boom": {
           "version": "2.10.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "brace-expansion": {
           "version": "1.1.7",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "balanced-match": "0.4.2",
+            "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
           }
         },
         "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -1945,37 +1952,43 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "dashdash": {
@@ -1984,7 +1997,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -2013,7 +2026,8 @@
         "delayed-stream": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -2033,7 +2047,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "extend": {
@@ -2045,7 +2059,8 @@
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -2059,25 +2074,27 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
           }
         },
         "fstream-ignore": {
@@ -2086,9 +2103,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
+            "fstream": "^1.0.0",
+            "inherits": "2",
+            "minimatch": "^3.0.0"
           }
         },
         "gauge": {
@@ -2097,14 +2114,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "getpass": {
@@ -2113,7 +2130,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -2128,19 +2145,21 @@
           "version": "7.1.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "graceful-fs": {
           "version": "4.1.11",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "har-schema": {
           "version": "1.0.5",
@@ -2154,8 +2173,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
           }
         },
         "has-unicode": {
@@ -2168,17 +2187,19 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
           "version": "2.16.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "http-signature": {
           "version": "1.1.1",
@@ -2186,24 +2207,26 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.4",
@@ -2215,8 +2238,9 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-typedarray": {
@@ -2228,7 +2252,8 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -2242,7 +2267,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "jsbn": {
@@ -2263,7 +2288,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -2301,33 +2326,38 @@
         "mime-db": {
           "version": "1.27.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "mime-db": "1.27.0"
+            "mime-db": "~1.27.0"
           }
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2344,17 +2374,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.2",
+            "detect-libc": "^1.0.2",
             "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
+            "mkdirp": "^0.5.1",
+            "nopt": "^4.0.1",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
             "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^2.2.1",
+            "tar-pack": "^3.4.0"
           }
         },
         "nopt": {
@@ -2363,8 +2393,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npmlog": {
@@ -2373,16 +2403,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -2400,8 +2431,9 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -2422,14 +2454,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "performance-now": {
           "version": "0.2.0",
@@ -2440,7 +2473,8 @@
         "process-nextick-args": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -2460,10 +2494,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -2478,14 +2512,15 @@
           "version": "2.2.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
+            "buffer-shims": "~1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
           }
         },
         "request": {
@@ -2494,42 +2529,44 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
           }
         },
         "rimraf": {
           "version": "2.6.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.3.0",
@@ -2553,8 +2590,9 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "sshpk": {
@@ -2563,15 +2601,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jodid25519": "^1.0.0",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -2586,18 +2624,20 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "stringstream": {
@@ -2610,8 +2650,9 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -2624,10 +2665,11 @@
           "version": "2.2.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
           }
         },
         "tar-pack": {
@@ -2636,14 +2678,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
+            "debug": "^2.2.0",
+            "fstream": "^1.0.10",
+            "fstream-ignore": "^1.0.5",
+            "once": "^1.3.3",
+            "readable-stream": "^2.1.4",
+            "rimraf": "^2.5.1",
+            "tar": "^2.2.1",
+            "uid-number": "^0.0.6"
           }
         },
         "tough-cookie": {
@@ -2652,7 +2694,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         },
         "tunnel-agent": {
@@ -2661,7 +2703,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -2679,7 +2721,8 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -2702,13 +2745,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2730,12 +2774,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -2744,8 +2788,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -2754,7 +2798,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "globs-to-files": {
@@ -2763,10 +2807,10 @@
       "integrity": "sha1-VEkPbR9Ln9LenZlEUUb/s3VQOA0=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3",
-        "asyncreduce": "0.1.4",
-        "glob": "5.0.15",
-        "xtend": "4.0.1"
+        "array-uniq": "~1.0.2",
+        "asyncreduce": "~0.1.4",
+        "glob": "^5.0.10",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "glob": {
@@ -2775,11 +2819,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -2796,8 +2840,8 @@
       "integrity": "sha1-npsTCpPjiUkTItl1zz7BgYw3zjQ=",
       "dev": true,
       "requires": {
-        "optimist": "0.3.7",
-        "uglify-js": "2.3.6"
+        "optimist": "~0.3",
+        "uglify-js": "~2.3"
       }
     },
     "has": {
@@ -2806,7 +2850,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.0.2"
       }
     },
     "has-flag": {
@@ -2821,7 +2865,7 @@
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "hash.js": {
@@ -2830,8 +2874,8 @@
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "hawk": {
@@ -2840,10 +2884,10 @@
       "integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
       "dev": true,
       "requires": {
-        "boom": "0.4.2",
-        "cryptiles": "0.2.2",
-        "hoek": "0.9.1",
-        "sntp": "0.2.4"
+        "boom": "0.4.x",
+        "cryptiles": "0.2.x",
+        "hoek": "0.9.x",
+        "sntp": "0.2.x"
       }
     },
     "hbs": {
@@ -2862,8 +2906,8 @@
           "integrity": "sha1-GMbTRAw16RsZs/9YK5FRq0mF1Pw=",
           "dev": true,
           "requires": {
-            "optimist": "0.3.7",
-            "uglify-js": "2.3.6"
+            "optimist": "~0.3",
+            "uglify-js": "~2.3"
           }
         }
       }
@@ -2886,9 +2930,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hoek": {
@@ -2912,7 +2956,7 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.4.0"
+        "statuses": ">= 1.3.1 < 2"
       },
       "dependencies": {
         "depd": {
@@ -2935,8 +2979,8 @@
       "integrity": "sha1-xQ0vsG7KedQjjmb9lDk9LkHmN0A=",
       "dev": true,
       "requires": {
-        "eventemitter3": "1.2.0",
-        "requires-port": "0.0.1"
+        "eventemitter3": "1.x.x",
+        "requires-port": "0.x.x"
       }
     },
     "http-signature": {
@@ -2946,7 +2990,7 @@
       "dev": true,
       "requires": {
         "asn1": "0.1.11",
-        "assert-plus": "0.1.5",
+        "assert-plus": "^0.1.5",
         "ctype": "0.5.3"
       }
     },
@@ -2986,8 +3030,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -3002,7 +3046,7 @@
       "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "~0.5.3"
       }
     },
     "insert-module-globals": {
@@ -3011,14 +3055,14 @@
       "integrity": "sha512-p3s7g96Nm62MbHRuj9ZXab0DuJNWD7qcmdUXCOQ/ZZn42DtDXfsLill7bq19lDCx3K3StypqUnuE3H2VmIJFUw==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
-        "combine-source-map": "0.7.2",
-        "concat-stream": "1.5.2",
-        "is-buffer": "1.1.6",
-        "lexical-scope": "1.2.0",
-        "process": "0.11.10",
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
+        "JSONStream": "^1.0.3",
+        "combine-source-map": "~0.7.1",
+        "concat-stream": "~1.5.1",
+        "is-buffer": "^1.1.0",
+        "lexical-scope": "^1.2.0",
+        "process": "~0.11.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "combine-source-map": {
@@ -3027,10 +3071,10 @@
           "integrity": "sha1-CHAxKFazB6h8xKxIbzqaYq7MwJ4=",
           "dev": true,
           "requires": {
-            "convert-source-map": "1.1.3",
-            "inline-source-map": "0.6.2",
-            "lodash.memoize": "3.0.4",
-            "source-map": "0.5.7"
+            "convert-source-map": "~1.1.0",
+            "inline-source-map": "~0.6.0",
+            "lodash.memoize": "~3.0.3",
+            "source-map": "~0.5.3"
           }
         }
       }
@@ -3047,7 +3091,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -3068,7 +3112,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -3089,7 +3133,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-number": {
@@ -3098,7 +3142,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-posix-bracket": {
@@ -3146,18 +3190,18 @@
       "integrity": "sha1-hwVFoNT0tM4WEDnp6AWpjCxwC9k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9",
-        "async": "0.9.2",
-        "escodegen": "1.3.3",
-        "esprima": "1.2.5",
-        "fileset": "0.1.8",
-        "handlebars": "1.3.0",
-        "js-yaml": "3.11.0",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "resolve": "0.7.4",
-        "which": "1.0.9",
-        "wordwrap": "0.0.3"
+        "abbrev": "1.0.x",
+        "async": "0.9.x",
+        "escodegen": "1.3.x",
+        "esprima": "1.2.x",
+        "fileset": "0.1.x",
+        "handlebars": "1.3.x",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "resolve": "0.7.x",
+        "which": "1.0.x",
+        "wordwrap": "0.0.x"
       },
       "dependencies": {
         "resolve": {
@@ -3174,10 +3218,10 @@
       "integrity": "sha1-g8TBPBKOGg1qFHeSORrzwVqKuOA=",
       "dev": true,
       "requires": {
-        "archiver": "0.14.4",
-        "body-parser": "1.12.4",
-        "express": "4.16.3",
-        "istanbul": "0.4.5"
+        "archiver": "0.14.x",
+        "body-parser": "~1.12.3",
+        "express": "4.x",
+        "istanbul": "0.4.x"
       },
       "dependencies": {
         "accepts": {
@@ -3186,7 +3230,7 @@
           "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
           "dev": true,
           "requires": {
-            "mime-types": "2.1.18",
+            "mime-types": "~2.1.18",
             "negotiator": "0.6.1"
           }
         },
@@ -3196,14 +3240,14 @@
           "integrity": "sha1-W53bn17hzu8hy487Ag5iQOy0MVw=",
           "dev": true,
           "requires": {
-            "async": "0.9.2",
-            "buffer-crc32": "0.2.1",
-            "glob": "4.3.5",
-            "lazystream": "0.1.0",
-            "lodash": "3.2.0",
-            "readable-stream": "1.0.34",
-            "tar-stream": "1.1.5",
-            "zip-stream": "0.5.2"
+            "async": "~0.9.0",
+            "buffer-crc32": "~0.2.1",
+            "glob": "~4.3.0",
+            "lazystream": "~0.1.0",
+            "lodash": "~3.2.0",
+            "readable-stream": "~1.0.26",
+            "tar-stream": "~1.1.0",
+            "zip-stream": "~0.5.0"
           }
         },
         "bytes": {
@@ -3251,11 +3295,11 @@
           "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
           "dev": true,
           "requires": {
-            "esprima": "2.7.3",
-            "estraverse": "1.9.3",
-            "esutils": "2.0.2",
-            "optionator": "0.8.2",
-            "source-map": "0.2.0"
+            "esprima": "^2.7.1",
+            "estraverse": "^1.9.1",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.2.0"
           }
         },
         "esprima": {
@@ -3282,36 +3326,36 @@
           "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
           "dev": true,
           "requires": {
-            "accepts": "1.3.5",
+            "accepts": "~1.3.5",
             "array-flatten": "1.1.1",
             "body-parser": "1.18.2",
             "content-disposition": "0.5.2",
-            "content-type": "1.0.4",
+            "content-type": "~1.0.4",
             "cookie": "0.3.1",
             "cookie-signature": "1.0.6",
             "debug": "2.6.9",
-            "depd": "1.1.2",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
+            "depd": "~1.1.2",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
             "finalhandler": "1.1.1",
             "fresh": "0.5.2",
             "merge-descriptors": "1.0.1",
-            "methods": "1.1.2",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
+            "methods": "~1.1.2",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
             "path-to-regexp": "0.1.7",
-            "proxy-addr": "2.0.3",
+            "proxy-addr": "~2.0.3",
             "qs": "6.5.1",
-            "range-parser": "1.2.0",
+            "range-parser": "~1.2.0",
             "safe-buffer": "5.1.1",
             "send": "0.16.2",
             "serve-static": "1.13.2",
             "setprototypeof": "1.1.0",
-            "statuses": "1.4.0",
-            "type-is": "1.6.16",
+            "statuses": "~1.4.0",
+            "type-is": "~1.6.16",
             "utils-merge": "1.0.1",
-            "vary": "1.1.2"
+            "vary": "~1.1.2"
           },
           "dependencies": {
             "body-parser": {
@@ -3321,15 +3365,15 @@
               "dev": true,
               "requires": {
                 "bytes": "3.0.0",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "http-errors": "1.6.2",
+                "depd": "~1.1.1",
+                "http-errors": "~1.6.2",
                 "iconv-lite": "0.4.19",
-                "on-finished": "2.3.0",
+                "on-finished": "~2.3.0",
                 "qs": "6.5.1",
                 "raw-body": "2.3.2",
-                "type-is": "1.6.16"
+                "type-is": "~1.6.15"
               }
             }
           }
@@ -3346,10 +3390,10 @@
           "integrity": "sha1-gPuwjKVA8jiszl0R0em8QedRc9M=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^2.0.1",
+            "once": "^1.3.0"
           }
         },
         "handlebars": {
@@ -3358,10 +3402,10 @@
           "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
           "dev": true,
           "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.8.29"
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
           },
           "dependencies": {
             "async": {
@@ -3376,7 +3420,7 @@
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "dev": true,
               "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
               }
             }
           }
@@ -3399,20 +3443,20 @@
           "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9",
-            "async": "1.5.2",
-            "escodegen": "1.8.1",
-            "esprima": "2.7.3",
-            "glob": "5.0.15",
-            "handlebars": "4.0.11",
-            "js-yaml": "3.11.0",
-            "mkdirp": "0.5.1",
-            "nopt": "3.0.6",
-            "once": "1.4.0",
-            "resolve": "1.1.7",
-            "supports-color": "3.1.2",
-            "which": "1.3.0",
-            "wordwrap": "1.0.0"
+            "abbrev": "1.0.x",
+            "async": "1.x",
+            "escodegen": "1.8.x",
+            "esprima": "2.7.x",
+            "glob": "^5.0.15",
+            "handlebars": "^4.0.1",
+            "js-yaml": "3.x",
+            "mkdirp": "0.5.x",
+            "nopt": "3.x",
+            "once": "1.x",
+            "resolve": "1.1.x",
+            "supports-color": "^3.1.0",
+            "which": "^1.1.1",
+            "wordwrap": "^1.0.0"
           },
           "dependencies": {
             "async": {
@@ -3427,11 +3471,11 @@
               "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
               "dev": true,
               "requires": {
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "2.0.10",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             }
           }
@@ -3466,7 +3510,7 @@
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.0.0"
           }
         },
         "minimist": {
@@ -3496,8 +3540,8 @@
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.10",
-            "wordwrap": "0.0.3"
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
           },
           "dependencies": {
             "wordwrap": {
@@ -3538,10 +3582,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "resolve": {
@@ -3557,18 +3601,18 @@
           "dev": true,
           "requires": {
             "debug": "2.6.9",
-            "depd": "1.1.2",
-            "destroy": "1.0.4",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
+            "depd": "~1.1.2",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
             "fresh": "0.5.2",
-            "http-errors": "1.6.2",
+            "http-errors": "~1.6.2",
             "mime": "1.4.1",
             "ms": "2.0.0",
-            "on-finished": "2.3.0",
-            "range-parser": "1.2.0",
-            "statuses": "1.4.0"
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.4.0"
           }
         },
         "source-map": {
@@ -3578,7 +3622,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "string_decoder": {
@@ -3594,9 +3638,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           },
           "dependencies": {
             "source-map": {
@@ -3620,7 +3664,7 @@
           "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         },
         "wordwrap": {
@@ -3635,9 +3679,9 @@
           "integrity": "sha1-Mty8UG0Nq00hNyYlvX66rDwv/1Y=",
           "dev": true,
           "requires": {
-            "compress-commons": "0.2.9",
-            "lodash": "3.2.0",
-            "readable-stream": "1.0.34"
+            "compress-commons": "~0.2.0",
+            "lodash": "~3.2.0",
+            "readable-stream": "~1.0.26"
           }
         }
       }
@@ -3648,8 +3692,8 @@
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -3666,7 +3710,7 @@
       "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -3705,7 +3749,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "labeled-stream-splicer": {
@@ -3714,9 +3758,9 @@
       "integrity": "sha1-pS4dE4AkwAuGscDJH2d5GLiuClk=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "isarray": "0.0.1",
-        "stream-splicer": "2.0.0"
+        "inherits": "^2.0.1",
+        "isarray": "~0.0.1",
+        "stream-splicer": "^2.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -3740,7 +3784,7 @@
       "integrity": "sha1-GyXWPHcqTCDwpe0KnXf0hLbhaSA=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.0.34"
+        "readable-stream": "~1.0.2"
       },
       "dependencies": {
         "isarray": {
@@ -3755,10 +3799,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -3775,8 +3819,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lexical-scope": {
@@ -3785,7 +3829,7 @@
       "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
       "dev": true,
       "requires": {
-        "astw": "2.2.0"
+        "astw": "^2.0.0"
       }
     },
     "load-script": {
@@ -3817,7 +3861,7 @@
           "integrity": "sha1-TW0L1x/60NpLpPbYdtXusE4HSAs=",
           "dev": true,
           "requires": {
-            "wordwrap": "0.0.3"
+            "wordwrap": "~0.0.2"
           }
         },
         "request": {
@@ -3826,8 +3870,8 @@
           "integrity": "sha1-Y0fX1E5S3FiBCMwc5c7pdfyJJt4=",
           "dev": true,
           "requires": {
-            "form-data": "0.0.3",
-            "mime": "1.2.7"
+            "form-data": "~0.0.3",
+            "mime": "~1.2.7"
           },
           "dependencies": {
             "form-data": {
@@ -3835,9 +3879,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "async": "0.1.9",
+                "async": "~0.1.9",
                 "combined-stream": "0.0.3",
-                "mime": "1.2.7"
+                "mime": "~1.2.2"
               },
               "dependencies": {
                 "async": {
@@ -3895,7 +3939,7 @@
       "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "2.4.1"
+        "lodash._objecttypes": "~2.4.1"
       }
     },
     "lodash.defaults": {
@@ -3904,8 +3948,8 @@
       "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "2.4.1",
-        "lodash.keys": "2.4.1"
+        "lodash._objecttypes": "~2.4.1",
+        "lodash.keys": "~2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -3914,9 +3958,9 @@
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "dev": true,
           "requires": {
-            "lodash._isnative": "2.4.1",
-            "lodash._shimkeys": "2.4.1",
-            "lodash.isobject": "2.4.1"
+            "lodash._isnative": "~2.4.1",
+            "lodash._shimkeys": "~2.4.1",
+            "lodash.isobject": "~2.4.1"
           }
         }
       }
@@ -3927,7 +3971,7 @@
       "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "2.4.1"
+        "lodash._objecttypes": "~2.4.1"
       }
     },
     "lodash.memoize": {
@@ -3940,7 +3984,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "lru-cache": {
       "version": "2.7.3",
@@ -3954,8 +3999,8 @@
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       },
       "dependencies": {
         "hash-base": {
@@ -3964,8 +4009,8 @@
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         }
       }
@@ -3994,19 +4039,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "miller-rabin": {
@@ -4015,8 +4060,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime": {
@@ -4037,7 +4082,7 @@
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "dev": true,
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "minimalistic-assert": {
@@ -4058,7 +4103,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -4147,7 +4192,7 @@
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -4158,21 +4203,21 @@
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
-        "browser-resolve": "1.11.2",
-        "cached-path-relative": "1.0.1",
-        "concat-stream": "1.5.2",
-        "defined": "1.0.0",
-        "detective": "4.7.1",
-        "duplexer2": "0.1.4",
-        "inherits": "2.0.3",
-        "parents": "1.0.1",
-        "readable-stream": "2.3.5",
-        "resolve": "1.5.0",
-        "stream-combiner2": "1.1.1",
-        "subarg": "1.0.0",
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
+        "JSONStream": "^1.0.3",
+        "browser-resolve": "^1.7.0",
+        "cached-path-relative": "^1.0.0",
+        "concat-stream": "~1.5.0",
+        "defined": "^1.0.0",
+        "detective": "^4.0.0",
+        "duplexer2": "^0.1.2",
+        "inherits": "^2.0.1",
+        "parents": "^1.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.1.3",
+        "stream-combiner2": "^1.1.1",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "ms": {
@@ -4187,7 +4232,7 @@
       "integrity": "sha1-abHyX/B00oKJBPJE3dBrfZbvbJM=",
       "dev": true,
       "requires": {
-        "strip-indent": "1.0.1"
+        "strip-indent": "^1.0.0"
       }
     },
     "multiparty": {
@@ -4196,8 +4241,8 @@
       "integrity": "sha1-pWfCrwAK0i3I8qZT2Rl4rh9TFvQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14",
-        "stream-counter": "0.2.0"
+        "readable-stream": "~1.1.9",
+        "stream-counter": "~0.2.0"
       },
       "dependencies": {
         "isarray": {
@@ -4212,10 +4257,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -4269,7 +4314,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9"
+        "abbrev": "1"
       }
     },
     "normalize-path": {
@@ -4278,7 +4323,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "oauth-sign": {
@@ -4299,8 +4344,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "on-finished": {
@@ -4324,7 +4369,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "opener": {
@@ -4339,7 +4384,7 @@
       "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
       "dev": true,
       "requires": {
-        "wordwrap": "0.0.3"
+        "wordwrap": "~0.0.2"
       }
     },
     "optionator": {
@@ -4348,12 +4393,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -4382,7 +4427,7 @@
       "integrity": "sha1-UM+GFjZeh+Ax4ppeyTOaPaRyX6I=",
       "dev": true,
       "requires": {
-        "shell-quote": "1.6.1"
+        "shell-quote": "^1.4.2"
       }
     },
     "pako": {
@@ -4397,7 +4442,7 @@
       "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
       "dev": true,
       "requires": {
-        "path-platform": "0.11.15"
+        "path-platform": "~0.11.15"
       }
     },
     "parse-asn1": {
@@ -4406,11 +4451,11 @@
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "dev": true,
       "requires": {
-        "asn1.js": "4.10.1",
-        "browserify-aes": "1.1.1",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.14"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
       }
     },
     "parse-glob": {
@@ -4419,10 +4464,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parseurl": {
@@ -4473,11 +4518,11 @@
       "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
       "dev": true,
       "requires": {
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.10"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "prelude-ls": {
@@ -4510,7 +4555,7 @@
       "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.6.0"
       }
     },
@@ -4520,11 +4565,11 @@
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "parse-asn1": "5.1.0",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
       }
     },
     "punycode": {
@@ -4563,8 +4608,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -4573,7 +4618,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4582,7 +4627,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -4593,7 +4638,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -4604,7 +4649,7 @@
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -4613,8 +4658,8 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.1"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "range-parser": {
@@ -4629,7 +4674,7 @@
       "integrity": "sha1-x0swBN6l3v0WlhcRBqx0DsMdYr4=",
       "dev": true,
       "requires": {
-        "bytes": "0.2.1"
+        "bytes": "~0.2.1"
       },
       "dependencies": {
         "bytes": {
@@ -4646,7 +4691,7 @@
       "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.5"
+        "readable-stream": "^2.0.2"
       }
     },
     "readable-stream": {
@@ -4655,13 +4700,13 @@
       "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -4670,10 +4715,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.5",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "reduce-component": {
@@ -4688,7 +4733,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "remove-trailing-separator": {
@@ -4715,21 +4760,21 @@
       "integrity": "sha1-NZGV1S6vcgvGl0JXnQStbSZagnQ=",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.5.0",
-        "bl": "0.9.5",
-        "caseless": "0.6.0",
-        "forever-agent": "0.5.2",
-        "form-data": "0.1.4",
+        "aws-sign2": "~0.5.0",
+        "bl": "~0.9.0",
+        "caseless": "~0.6.0",
+        "forever-agent": "~0.5.0",
+        "form-data": "~0.1.0",
         "hawk": "1.1.1",
-        "http-signature": "0.10.1",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "1.0.2",
-        "node-uuid": "1.4.8",
-        "oauth-sign": "0.4.0",
-        "qs": "1.2.2",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.4.3"
+        "http-signature": "~0.10.0",
+        "json-stringify-safe": "~5.0.0",
+        "mime-types": "~1.0.1",
+        "node-uuid": "~1.4.0",
+        "oauth-sign": "~0.4.0",
+        "qs": "~1.2.0",
+        "stringstream": "~0.0.4",
+        "tough-cookie": ">=0.12.0",
+        "tunnel-agent": "~0.4.0"
       },
       "dependencies": {
         "mime-types": {
@@ -4758,7 +4803,7 @@
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "right-align": {
@@ -4768,7 +4813,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -4783,8 +4828,8 @@
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
       "dev": true,
       "requires": {
-        "hash-base": "2.0.2",
-        "inherits": "2.0.3"
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "runnel": {
@@ -4811,9 +4856,9 @@
       "integrity": "sha1-vnDY0b4B3mGCGvE3gLUDRaT3Gr0=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "*",
         "fresh": "0.2.0",
-        "mime": "1.2.11",
+        "mime": "~1.2.9",
         "range-parser": "0.0.4"
       }
     },
@@ -4829,9 +4874,9 @@
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.2"
       },
       "dependencies": {
@@ -4890,18 +4935,18 @@
           "dev": true,
           "requires": {
             "debug": "2.6.9",
-            "depd": "1.1.2",
-            "destroy": "1.0.4",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
+            "depd": "~1.1.2",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
             "fresh": "0.5.2",
-            "http-errors": "1.6.2",
+            "http-errors": "~1.6.2",
             "mime": "1.4.1",
             "ms": "2.0.0",
-            "on-finished": "2.3.0",
-            "range-parser": "1.2.0",
-            "statuses": "1.4.0"
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.4.0"
           }
         }
       }
@@ -4924,8 +4969,8 @@
       "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shallow-copy": {
@@ -4940,8 +4985,8 @@
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
       "dev": true,
       "requires": {
-        "json-stable-stringify": "0.0.1",
-        "sha.js": "2.4.10"
+        "json-stable-stringify": "~0.0.0",
+        "sha.js": "~2.4.4"
       }
     },
     "shell-quote": {
@@ -4950,10 +4995,10 @@
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "dev": true,
       "requires": {
-        "array-filter": "0.0.1",
-        "array-map": "0.0.0",
-        "array-reduce": "0.0.0",
-        "jsonify": "0.0.0"
+        "array-filter": "~0.0.0",
+        "array-map": "~0.0.0",
+        "array-reduce": "~0.0.0",
+        "jsonify": "~0.0.0"
       }
     },
     "sigmund": {
@@ -4968,7 +5013,7 @@
       "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
       "dev": true,
       "requires": {
-        "hoek": "0.9.1"
+        "hoek": "0.9.x"
       }
     },
     "source-map": {
@@ -4989,7 +5034,7 @@
       "integrity": "sha1-8HEHRMRT1VH8cUPq2YPaYBTjNsw=",
       "dev": true,
       "requires": {
-        "through": "1.1.2"
+        "through": "1"
       },
       "dependencies": {
         "through": {
@@ -5013,9 +5058,9 @@
       "dev": true,
       "requires": {
         "array-map": "0.0.0",
-        "foreach-shim": "0.1.1",
+        "foreach-shim": "~0.1.1",
         "isarray": "0.0.1",
-        "source-map-cjs": "0.1.32"
+        "source-map-cjs": "~0.1.31"
       },
       "dependencies": {
         "isarray": {
@@ -5043,8 +5088,8 @@
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.5"
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-combiner2": {
@@ -5053,8 +5098,8 @@
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "dev": true,
       "requires": {
-        "duplexer2": "0.1.4",
-        "readable-stream": "2.3.5"
+        "duplexer2": "~0.1.0",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-counter": {
@@ -5063,7 +5108,7 @@
       "integrity": "sha1-3tJmVWMZyLDiIoErnPOyb6fZR94=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "~1.1.8"
       },
       "dependencies": {
         "isarray": {
@@ -5078,10 +5123,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -5098,11 +5143,11 @@
       "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.5",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.3",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "stream-splicer": {
@@ -5111,8 +5156,8 @@
       "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.5"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "string_decoder": {
@@ -5121,7 +5166,7 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {
@@ -5136,7 +5181,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "subarg": {
@@ -5145,7 +5190,7 @@
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "dev": true,
       "requires": {
-        "minimist": "1.2.0"
+        "minimist": "^1.1.0"
       }
     },
     "superagent": {
@@ -5155,7 +5200,7 @@
       "dev": true,
       "requires": {
         "cookiejar": "1.3.0",
-        "debug": "0.7.4",
+        "debug": "~0.7.2",
         "emitter-component": "1.0.0",
         "formidable": "1.0.14",
         "methods": "0.0.1",
@@ -5196,7 +5241,7 @@
       "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
       "dev": true,
       "requires": {
-        "has-flag": "1.0.0"
+        "has-flag": "^1.0.0"
       }
     },
     "syntax-error": {
@@ -5205,7 +5250,7 @@
       "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
       "dev": true,
       "requires": {
-        "acorn-node": "1.3.0"
+        "acorn-node": "^1.2.0"
       }
     },
     "tap-finished": {
@@ -5214,8 +5259,8 @@
       "integrity": "sha1-CLW1Q/3ASDApDGxWEnlVLnHEvWc=",
       "dev": true,
       "requires": {
-        "tap-parser": "0.2.1",
-        "through": "2.3.8"
+        "tap-parser": "~0.2.0",
+        "through": "~2.3.4"
       },
       "dependencies": {
         "tap-parser": {
@@ -5224,7 +5269,7 @@
           "integrity": "sha1-jh6CPyEU7iHQMuLzHk+2QqKW9Qs=",
           "dev": true,
           "requires": {
-            "split": "0.1.2"
+            "split": "~0.1.2"
           }
         }
       }
@@ -5235,9 +5280,9 @@
       "integrity": "sha1-coph1kaApbSNXb2dvQpNSPXDW8s=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimist": "0.2.0",
-        "readable-stream": "1.1.14"
+        "inherits": "~2.0.1",
+        "minimist": "^0.2.0",
+        "readable-stream": "~1.1.11"
       },
       "dependencies": {
         "isarray": {
@@ -5258,10 +5303,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -5278,10 +5323,10 @@
       "integrity": "sha1-vpIYwTDCACnhB7D5Z/sj3gV50Tw=",
       "dev": true,
       "requires": {
-        "bl": "0.9.5",
-        "end-of-stream": "1.4.1",
-        "readable-stream": "1.0.34",
-        "xtend": "4.0.1"
+        "bl": "^0.9.0",
+        "end-of-stream": "^1.0.0",
+        "readable-stream": "~1.0.33",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -5296,10 +5341,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -5322,8 +5367,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.5",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "timers-browserify": {
@@ -5332,7 +5377,7 @@
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "dev": true,
       "requires": {
-        "process": "0.11.10"
+        "process": "~0.11.0"
       }
     },
     "to-arraybuffer": {
@@ -5347,7 +5392,7 @@
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "tty-browserify": {
@@ -5368,7 +5413,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-is": {
@@ -5378,7 +5423,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.18"
+        "mime-types": "~2.1.18"
       }
     },
     "typedarray": {
@@ -5393,9 +5438,9 @@
       "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
       "dev": true,
       "requires": {
-        "async": "0.2.10",
-        "optimist": "0.3.7",
-        "source-map": "0.1.43"
+        "async": "~0.2.6",
+        "optimist": "~0.3.5",
+        "source-map": "~0.1.7"
       },
       "dependencies": {
         "async": {
@@ -5410,7 +5455,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -5526,7 +5571,7 @@
       "integrity": "sha1-WtofjknkfUt0Rdi+ei4eYxq0MBY=",
       "dev": true,
       "requires": {
-        "forEachAsync": "2.2.1"
+        "forEachAsync": "~2.2"
       }
     },
     "watchify": {
@@ -5535,13 +5580,13 @@
       "integrity": "sha1-7i8sXIw3MSMD+Zi4GLKzRQ7v5kg=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "browserify": "13.3.0",
-        "chokidar": "1.7.0",
-        "defined": "1.0.0",
-        "outpipe": "1.1.1",
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
+        "anymatch": "^1.3.0",
+        "browserify": "^13.0.0",
+        "chokidar": "^1.0.0",
+        "defined": "^1.0.0",
+        "outpipe": "^1.1.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "browserify": {
@@ -5550,53 +5595,53 @@
           "integrity": "sha1-tanJAgJD8McORnW+yCI7xifkFc4=",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.2",
-            "assert": "1.4.1",
-            "browser-pack": "6.0.4",
-            "browser-resolve": "1.11.2",
-            "browserify-zlib": "0.1.4",
-            "buffer": "4.9.1",
-            "cached-path-relative": "1.0.1",
-            "concat-stream": "1.5.2",
-            "console-browserify": "1.1.0",
-            "constants-browserify": "1.0.0",
-            "crypto-browserify": "3.12.0",
-            "defined": "1.0.0",
-            "deps-sort": "2.0.0",
-            "domain-browser": "1.1.7",
-            "duplexer2": "0.1.4",
-            "events": "1.1.1",
-            "glob": "7.1.2",
-            "has": "1.0.1",
-            "htmlescape": "1.1.1",
-            "https-browserify": "0.0.1",
-            "inherits": "2.0.3",
-            "insert-module-globals": "7.0.2",
-            "labeled-stream-splicer": "2.0.0",
-            "module-deps": "4.1.1",
-            "os-browserify": "0.1.2",
-            "parents": "1.0.1",
-            "path-browserify": "0.0.0",
-            "process": "0.11.10",
-            "punycode": "1.4.1",
-            "querystring-es3": "0.2.1",
-            "read-only-stream": "2.0.0",
-            "readable-stream": "2.3.5",
-            "resolve": "1.5.0",
-            "shasum": "1.0.2",
-            "shell-quote": "1.6.1",
-            "stream-browserify": "2.0.1",
-            "stream-http": "2.8.1",
-            "string_decoder": "0.10.31",
-            "subarg": "1.0.0",
-            "syntax-error": "1.4.0",
-            "through2": "2.0.3",
-            "timers-browserify": "1.4.2",
-            "tty-browserify": "0.0.1",
-            "url": "0.11.0",
-            "util": "0.10.3",
-            "vm-browserify": "0.0.4",
-            "xtend": "4.0.1"
+            "JSONStream": "^1.0.3",
+            "assert": "^1.4.0",
+            "browser-pack": "^6.0.1",
+            "browser-resolve": "^1.11.0",
+            "browserify-zlib": "~0.1.2",
+            "buffer": "^4.1.0",
+            "cached-path-relative": "^1.0.0",
+            "concat-stream": "~1.5.1",
+            "console-browserify": "^1.1.0",
+            "constants-browserify": "~1.0.0",
+            "crypto-browserify": "^3.0.0",
+            "defined": "^1.0.0",
+            "deps-sort": "^2.0.0",
+            "domain-browser": "~1.1.0",
+            "duplexer2": "~0.1.2",
+            "events": "~1.1.0",
+            "glob": "^7.1.0",
+            "has": "^1.0.0",
+            "htmlescape": "^1.1.0",
+            "https-browserify": "~0.0.0",
+            "inherits": "~2.0.1",
+            "insert-module-globals": "^7.0.0",
+            "labeled-stream-splicer": "^2.0.0",
+            "module-deps": "^4.0.8",
+            "os-browserify": "~0.1.1",
+            "parents": "^1.0.1",
+            "path-browserify": "~0.0.0",
+            "process": "~0.11.0",
+            "punycode": "^1.3.2",
+            "querystring-es3": "~0.2.0",
+            "read-only-stream": "^2.0.0",
+            "readable-stream": "^2.0.2",
+            "resolve": "^1.1.4",
+            "shasum": "^1.0.0",
+            "shell-quote": "^1.6.1",
+            "stream-browserify": "^2.0.0",
+            "stream-http": "^2.0.0",
+            "string_decoder": "~0.10.0",
+            "subarg": "^1.0.0",
+            "syntax-error": "^1.1.1",
+            "through2": "^2.0.0",
+            "timers-browserify": "^1.0.1",
+            "tty-browserify": "~0.0.0",
+            "url": "~0.11.0",
+            "util": "~0.10.1",
+            "vm-browserify": "~0.0.1",
+            "xtend": "^4.0.0"
           }
         },
         "browserify-zlib": {
@@ -5605,7 +5650,7 @@
           "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
           "dev": true,
           "requires": {
-            "pako": "0.2.9"
+            "pako": "~0.2.0"
           }
         },
         "buffer": {
@@ -5614,9 +5659,9 @@
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "dev": true,
           "requires": {
-            "base64-js": "1.2.3",
-            "ieee754": "1.1.10",
-            "isarray": "1.0.0"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
           }
         },
         "https-browserify": {
@@ -5651,13 +5696,13 @@
       "integrity": "sha1-UicWx5p6EOeBrLssbK/liPcB/MA=",
       "dev": true,
       "requires": {
-        "archiver": "0.12.0",
-        "async": "0.9.2",
-        "lodash": "2.4.2",
-        "q": "1.0.1",
-        "request": "2.46.0",
-        "underscore.string": "2.3.3",
-        "vargs": "0.1.0"
+        "archiver": "~0.12.0",
+        "async": "~0.9.0",
+        "lodash": "~2.4.1",
+        "q": "~1.0.1",
+        "request": "~2.46.0",
+        "underscore.string": "~2.3.3",
+        "vargs": "~0.1.0"
       },
       "dependencies": {
         "archiver": {
@@ -5666,14 +5711,14 @@
           "integrity": "sha1-uMzeJQjKuQkrtxBmMBOcDzmigMw=",
           "dev": true,
           "requires": {
-            "async": "0.9.2",
-            "buffer-crc32": "0.2.1",
-            "glob": "4.0.6",
-            "lazystream": "0.1.0",
-            "lodash": "2.4.2",
-            "readable-stream": "1.0.34",
-            "tar-stream": "1.0.2",
-            "zip-stream": "0.4.1"
+            "async": "~0.9.0",
+            "buffer-crc32": "~0.2.1",
+            "glob": "~4.0.6",
+            "lazystream": "~0.1.0",
+            "lodash": "~2.4.1",
+            "readable-stream": "~1.0.26",
+            "tar-stream": "~1.0.0",
+            "zip-stream": "~0.4.0"
           }
         },
         "compress-commons": {
@@ -5682,9 +5727,9 @@
           "integrity": "sha1-DHQIcP3ljLpRbwrAyCLjOguF36M=",
           "dev": true,
           "requires": {
-            "buffer-crc32": "0.2.1",
-            "crc32-stream": "0.3.4",
-            "readable-stream": "1.0.34"
+            "buffer-crc32": "~0.2.1",
+            "crc32-stream": "~0.3.1",
+            "readable-stream": "~1.0.26"
           }
         },
         "glob": {
@@ -5693,10 +5738,10 @@
           "integrity": "sha1-aVxQvdTi+1xdNwsJHziNNwfikac=",
           "dev": true,
           "requires": {
-            "graceful-fs": "3.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "1.0.0",
-            "once": "1.4.0"
+            "graceful-fs": "^3.0.2",
+            "inherits": "2",
+            "minimatch": "^1.0.0",
+            "once": "^1.3.0"
           }
         },
         "graceful-fs": {
@@ -5705,7 +5750,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "1.1.2"
+            "natives": "^1.1.0"
           }
         },
         "isarray": {
@@ -5726,8 +5771,8 @@
           "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         },
         "readable-stream": {
@@ -5736,10 +5781,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -5754,10 +5799,10 @@
           "integrity": "sha1-/Rm0oXkA+nBPahM+MEWurQViq5U=",
           "dev": true,
           "requires": {
-            "bl": "0.9.5",
-            "end-of-stream": "1.4.1",
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "bl": "^0.9.0",
+            "end-of-stream": "^1.0.0",
+            "readable-stream": "^1.0.27-1",
+            "xtend": "^4.0.0"
           }
         },
         "zip-stream": {
@@ -5766,9 +5811,9 @@
           "integrity": "sha1-TqeVqM4Z6fq0mjHR0IdyFBWfA6M=",
           "dev": true,
           "requires": {
-            "compress-commons": "0.1.6",
-            "lodash": "2.4.2",
-            "readable-stream": "1.0.34"
+            "compress-commons": "~0.1.0",
+            "lodash": "~2.4.1",
+            "readable-stream": "~1.0.26"
           }
         }
       }
@@ -5810,8 +5855,8 @@
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "dev": true,
       "requires": {
-        "sax": "1.2.4",
-        "xmlbuilder": "9.0.7"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
       },
       "dependencies": {
         "xmlbuilder": {
@@ -5827,10 +5872,10 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
-    "xmldom": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+    "xmldom-alpha": {
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/xmldom-alpha/-/xmldom-alpha-0.1.28.tgz",
+      "integrity": "sha1-ToRR2N9Ne7MDuq4L3ngwYvnT1gA="
     },
     "xtend": {
       "version": "4.0.1",
@@ -5844,8 +5889,8 @@
       "integrity": "sha1-ZleJr8KtS5Ar9APwDoW2Q04PMwA=",
       "dev": true,
       "requires": {
-        "argparse": "0.1.16",
-        "glob": "3.1.21"
+        "argparse": "~0.1.4",
+        "glob": "~3.1.11"
       },
       "dependencies": {
         "argparse": {
@@ -5854,8 +5899,8 @@
           "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
           "dev": true,
           "requires": {
-            "underscore": "1.7.0",
-            "underscore.string": "2.4.0"
+            "underscore": "~1.7.0",
+            "underscore.string": "~2.4.0"
           }
         },
         "glob": {
@@ -5864,9 +5909,9 @@
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "dev": true,
           "requires": {
-            "graceful-fs": "1.2.3",
-            "inherits": "1.0.2",
-            "minimatch": "0.2.14"
+            "graceful-fs": "~1.2.0",
+            "inherits": "1",
+            "minimatch": "~0.2.11"
           }
         },
         "graceful-fs": {
@@ -5887,8 +5932,8 @@
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         },
         "underscore.string": {
@@ -5906,9 +5951,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
     },
@@ -5918,9 +5963,9 @@
       "integrity": "sha1-rvCVN2z+E4lZqBNBmB0mM4tG2NM=",
       "dev": true,
       "requires": {
-        "debug": "0.7.4",
-        "lodash.defaults": "2.4.1",
-        "readable-stream": "1.0.34"
+        "debug": "~0.7.4",
+        "lodash.defaults": "~2.4.1",
+        "readable-stream": "~1.0.24"
       },
       "dependencies": {
         "debug": {
@@ -5941,10 +5986,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -6014,53 +6059,53 @@
           "integrity": "sha1-jyI7sk/07kM15r6pZx3ilOQ7pqM=",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.2",
-            "assert": "1.3.0",
-            "browser-pack": "6.0.4",
-            "browser-resolve": "1.11.2",
-            "browserify-zlib": "0.1.4",
-            "buffer": "4.9.1",
-            "concat-stream": "1.5.2",
-            "console-browserify": "1.1.0",
-            "constants-browserify": "1.0.0",
-            "crypto-browserify": "3.12.0",
-            "defined": "1.0.0",
-            "deps-sort": "2.0.0",
-            "domain-browser": "1.1.7",
-            "duplexer2": "0.1.4",
-            "events": "1.1.1",
-            "glob": "5.0.15",
-            "has": "1.0.1",
-            "htmlescape": "1.1.1",
-            "https-browserify": "0.0.1",
-            "inherits": "2.0.3",
-            "insert-module-globals": "7.0.2",
+            "JSONStream": "^1.0.3",
+            "assert": "~1.3.0",
+            "browser-pack": "^6.0.1",
+            "browser-resolve": "^1.11.0",
+            "browserify-zlib": "~0.1.2",
+            "buffer": "^4.1.0",
+            "concat-stream": "~1.5.1",
+            "console-browserify": "^1.1.0",
+            "constants-browserify": "~1.0.0",
+            "crypto-browserify": "^3.0.0",
+            "defined": "^1.0.0",
+            "deps-sort": "^2.0.0",
+            "domain-browser": "~1.1.0",
+            "duplexer2": "~0.1.2",
+            "events": "~1.1.0",
+            "glob": "^5.0.15",
+            "has": "^1.0.0",
+            "htmlescape": "^1.1.0",
+            "https-browserify": "~0.0.0",
+            "inherits": "~2.0.1",
+            "insert-module-globals": "^7.0.0",
             "isarray": "0.0.1",
-            "labeled-stream-splicer": "2.0.0",
-            "module-deps": "4.1.1",
-            "os-browserify": "0.1.2",
-            "parents": "1.0.1",
-            "path-browserify": "0.0.0",
-            "process": "0.11.10",
-            "punycode": "1.4.1",
-            "querystring-es3": "0.2.1",
-            "read-only-stream": "2.0.0",
-            "readable-stream": "2.3.5",
-            "resolve": "1.5.0",
-            "shasum": "1.0.2",
-            "shell-quote": "1.6.1",
-            "stream-browserify": "2.0.1",
-            "stream-http": "2.8.1",
-            "string_decoder": "0.10.31",
-            "subarg": "1.0.0",
-            "syntax-error": "1.4.0",
-            "through2": "2.0.3",
-            "timers-browserify": "1.4.2",
-            "tty-browserify": "0.0.1",
-            "url": "0.11.0",
-            "util": "0.10.3",
-            "vm-browserify": "0.0.4",
-            "xtend": "4.0.1"
+            "labeled-stream-splicer": "^2.0.0",
+            "module-deps": "^4.0.2",
+            "os-browserify": "~0.1.1",
+            "parents": "^1.0.1",
+            "path-browserify": "~0.0.0",
+            "process": "~0.11.0",
+            "punycode": "^1.3.2",
+            "querystring-es3": "~0.2.0",
+            "read-only-stream": "^2.0.0",
+            "readable-stream": "^2.0.2",
+            "resolve": "^1.1.4",
+            "shasum": "^1.0.0",
+            "shell-quote": "^1.4.3",
+            "stream-browserify": "^2.0.0",
+            "stream-http": "^2.0.0",
+            "string_decoder": "~0.10.0",
+            "subarg": "^1.0.0",
+            "syntax-error": "^1.1.1",
+            "through2": "^2.0.0",
+            "timers-browserify": "^1.0.1",
+            "tty-browserify": "~0.0.0",
+            "url": "~0.11.0",
+            "util": "~0.10.1",
+            "vm-browserify": "~0.0.1",
+            "xtend": "^4.0.0"
           },
           "dependencies": {
             "shell-quote": {
@@ -6069,10 +6114,10 @@
               "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
               "dev": true,
               "requires": {
-                "array-filter": "0.0.1",
-                "array-map": "0.0.0",
-                "array-reduce": "0.0.0",
-                "jsonify": "0.0.0"
+                "array-filter": "~0.0.0",
+                "array-map": "~0.0.0",
+                "array-reduce": "~0.0.0",
+                "jsonify": "~0.0.0"
               }
             },
             "xtend": {
@@ -6089,7 +6134,7 @@
           "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
           "dev": true,
           "requires": {
-            "pako": "0.2.9"
+            "pako": "~0.2.0"
           }
         },
         "buffer": {
@@ -6098,9 +6143,9 @@
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "dev": true,
           "requires": {
-            "base64-js": "1.2.3",
-            "ieee754": "1.1.10",
-            "isarray": "1.0.0"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
           },
           "dependencies": {
             "isarray": {
@@ -6138,11 +6183,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "https-browserify": {
@@ -6181,10 +6226,10 @@
           "integrity": "sha1-rhhEK1NqCMcgI5sHnS8iisvt7kA=",
           "dev": true,
           "requires": {
-            "array-filter": "0.0.1",
-            "array-map": "0.0.0",
-            "array-reduce": "0.0.0",
-            "jsonify": "0.0.0"
+            "array-filter": "~0.0.0",
+            "array-map": "~0.0.0",
+            "array-reduce": "~0.0.0",
+            "jsonify": "~0.0.0"
           }
         },
         "string_decoder": {
@@ -6199,7 +6244,7 @@
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "dev": true,
           "requires": {
-            "object-keys": "0.4.0"
+            "object-keys": "~0.4.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plist",
   "description": "Mac OS X Plist parser/builder for Node.js and browsers",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": "Nathan Rajlich <nathan@tootallnate.net>",
   "contributors": [
     "Hans Huebner <hans.huebner@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "base64-js": "^1.2.3",
     "xmlbuilder": "^9.0.7",
-    "xmldom": "0.1.x"
+    "xmldom-alpha": "^0.1.28"
   },
   "devDependencies": {
     "browserify": "^16.1.1",


### PR DESCRIPTION
Update to xmldom version 0.1.28, which has been renamed to xmldom-alpha.
This change enables use of xmldom under MIT license instead of LGPL-2.0

Update plist.js version to 3.0.2