### PR TITLE
Add CodeQL Analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: "Code Scanning - Action"
+
+on:
+  push:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  CodeQL-Build:
+
+    strategy:
+      fail-fast: false
+
+
+    # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      # Override language selection by uncommenting this and choosing your languages
+      # with:
+      #   languages: go, javascript, csharp, python, cpp, java
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below).
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/lib/plist.js
+++ b/lib/plist.js
@@ -1,8 +1,11 @@
 ;(function (exports, DOMParser, xmlbuilder) {
 	// Checks if running in a non-browser environment
- 	var inNode = typeof window === 'undefined' ? true : false
- 	  , utf8_to_b64
- 	  , b64_to_utf8;
+
+	var inNode = typeof process !== "undefined" && process.versions && !!process.versions.node
+		  , utf8_to_b64
+		, b64_to_utf8;
+
+
 
  	// this library runs in browsers and nodejs, set up functions accordingly
  	if (inNode) {
@@ -295,7 +298,7 @@
     }
   };
 
-})(typeof exports === 'undefined' ? plist = {} : exports, typeof window === 'undefined' ? require('xmldom').DOMParser : null, typeof window === 'undefined' ? require('xmlbuilder') : xmlbuilder)
+})(typeof exports === 'undefined' ? plist = {} : exports, typeof require !== 'undefined' ? require('xmldom').DOMParser : null, typeof require !== 'undefined' ? require('xmlbuilder') : xmlbuilder)
 // the above line checks for exports (defined in node) and uses it, or creates
 // a global variable and exports to that. also, if in node, require DOMParser
 // node-style, in browser it should already be present

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "plist",
+  "name": "@atom/plist",
   "description": "Mac OS X Plist parser/builder for NodeJS. Convert a Plist file or string into a native JS object and native JS object into a Plist file.",
   "version": "0.4.3",
   "author": "Nathan Rajlich <nathan@tootallnate.net>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atom/plist",
   "description": "Mac OS X Plist parser/builder for NodeJS. Convert a Plist file or string into a native JS object and native JS object into a Plist file.",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "author": "Nathan Rajlich <nathan@tootallnate.net>",
   "contributors": [
     "Hans Huebner <hans.huebner@gmail.com>",
@@ -23,11 +23,11 @@
   ],
   "main": "./lib/plist",
   "dependencies": {
-    "xmlbuilder" : "0.4.x",
-    "xmldom" : "0.1.x"
+    "xmlbuilder": "0.4.x",
+    "xmldom": "0.1.x"
   },
   "devDependencies": {
-    "nodeunit" : "0.7.x"
+    "nodeunit": "0.7.x"
   },
   "scripts": {
     "test": "nodeunit tests"


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs CodeQL on every push, and on a daily schedule.

Code scanning looks for vulnerabilities, such as XSS, SQL injection, etc., in your code. If it finds any new vulnerabilities it surfaces them in the PR as check annotations, and blocks the build until they’re fixed or marked as false positives. If it finds any on the repo’s default branch it displays them in the [security tab](../security/code-scanning).

For now you also need to be feature flagged to see results in the security tab (as well as having write permission on this repo) - if you drop an email to jhutchings1@github.com I can get anyone you need added. 

Finally, this is an early access program, so please don't share screenshots/tweet about this before May 6th when we're unveiling it at GitHub Satellite. 

Cc: @greysteil
