### PR TITLE
Fix prototype pollution #114

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -153,6 +153,12 @@ function parsePlistXML (node) {
     if (isEmptyNode(node)) {
       return '';
     }
+
+    invariant(
+      node.childNodes[0].nodeValue !== '__proto__',
+      '__proto__ keys can lead to prototype pollution. More details on CVE-2022-22912'
+    );
+
     return node.childNodes[0].nodeValue;
   } else if (node.nodeName === 'string') {
     res = '';

--- a/test/parse.js
+++ b/test/parse.js
@@ -187,6 +187,13 @@ U=</data>
       );
       assert.deepEqual(parsed, { a: { a1: true } });
     });
+
+    /* Test to protect against CVE-2022-22912 */
+    it('should throw if key value is __proto__', function () {
+      assert.throws(function () {
+        parseFixture('<dict><key>__proto__</key><dict><key>length</key><string>polluted</string></dict></dict>');
+      });
+    });
   });
 
   describe('integration', function () {

--- a/test/parse.js
+++ b/test/parse.js
@@ -193,6 +193,11 @@ U=</data>
       assert.throws(function () {
         parseFixture('<dict><key>__proto__</key><dict><key>length</key><string>polluted</string></dict></dict>');
       });
+
+      // adding backslash should still be protected.
+      assert.throws(function () {
+        parseFixture('<dict><key>_\_proto_\_</key><dict><key>length</key><string>polluted</string></dict></dict>');
+      });
     });
   });
 


### PR DESCRIPTION
This PR fixes the basic attack for [CVE-2022-22912](https://nvd.nist.gov/vuln/detail/CVE-2022-22912). Issue #114.

This PR introduce a new invariant where `<key>` tags can't  have the `__proto__` value avoiding prototype pollution attacks. While testing I noticed both `__proto__` string and variations with backslash such as `_\_proto_\_` can trigger the vulnerability but both attacks are stopped by this fix.

I went through the codebase and the only vector of attack I found for this vulnerability was through the `dict` and `key` but would appreciate the maintainers advice in case I have missed something.