### PR TITLE
Fix data type ‘data‘ parsed error with encoded base64

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -197,14 +197,14 @@ function parsePlistXML (node) {
   } else if (node.nodeName === 'data') {
     res = '';
     if (isEmptyNode(node)) {
-      return Buffer.from(res, 'base64');
+      return require('buffer').Buffer.from(res, 'base64');
     }
     for (i=0; i < node.childNodes.length; i++) {
       if (node.childNodes[i].nodeType === TEXT_NODE) {
         res += node.childNodes[i].nodeValue.replace(/\s+/g, '');
       }
     }
-    return Buffer.from(res, 'base64');
+    return require('buffer').Buffer.from(res, 'base64');
 
   } else if (node.nodeName === 'date') {
     invariant(


### PR DESCRIPTION
Not able to parse 'data' tag