### PR TITLE
Add xmlbuilder-js CreateOptions parameter

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -50,12 +50,17 @@ function type (obj) {
  * Generate an XML plist string from the input object `obj`.
  *
  * @param {Object} obj - the object to convert
- * @param {Object} [opts] - optional options object
+ * @param {Object} [xmlToStringOpts] - optional XMLToStringOptions object
+ * @param {Object} [createOpts] - optional CreateOptions object
  * @returns {String} converted plist XML string
  * @api public
  */
 
-function build (obj, opts) {
+function build (obj, xmlToStringOpts, createOpts) {
+  if (xmlToStringOpts === undefined) xmlToStringOpts = {};
+  if (createOpts === undefined) createOpts = {};
+  xmlToStringOpts.pretty = xmlToStringOpts.pretty !== false;
+
   var XMLHDR = {
     version: '1.0',
     encoding: 'UTF-8'
@@ -66,7 +71,7 @@ function build (obj, opts) {
     sysid: 'http://www.apple.com/DTDs/PropertyList-1.0.dtd'
   };
 
-  var doc = xmlbuilder.create('plist');
+  var doc = xmlbuilder.create('plist', createOpts);
 
   doc.dec(XMLHDR.version, XMLHDR.encoding, XMLHDR.standalone);
   doc.dtd(XMLDTD.pubid, XMLDTD.sysid);
@@ -74,10 +79,7 @@ function build (obj, opts) {
 
   walk_obj(obj, doc);
 
-  if (!opts) opts = {};
-  // default `pretty` to `true`
-  opts.pretty = opts.pretty !== false;
-  return doc.end(opts);
+  return doc.end(xmlToStringOpts);
 }
 
 /**


### PR DESCRIPTION
This enables the passing of a configuration object to the `create` method of xmlbuilder-js.