### PR TITLE
fix: escape carriage returns in browser build()

### DIFF
--- a/.changeset/escape-cr-browser-build.md
+++ b/.changeset/escape-cr-browser-build.md
@@ -1,0 +1,5 @@
+---
+"plist": patch
+---
+
+Escape carriage returns in the browser `build()` so strings and keys containing CR survive a round-trip

--- a/src/build.browser.ts
+++ b/src/build.browser.ts
@@ -109,5 +109,10 @@ function escapeXml(str: string): string {
   return str
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
+    .replace(/>/g, '&gt;')
+    // A literal carriage return in text content is normalized to a line feed
+    // when the plist is parsed back (XML line-ending normalization), so encode
+    // it as a character reference to keep `parse(build(x))` lossless. This
+    // matches the Node `build()`, which emits `&#xD;` via `xmlbuilder`.
+    .replace(/\r/g, '&#xD;');
 }

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { build } from '../src/index.js';
+import { build, parse } from '../src/index.js';
+import { build as browserBuild } from '../src/build.browser.js';
 
 describe('plist', () => {
 
@@ -150,6 +151,32 @@ describe('plist', () => {
   </array>
 </plist>`);
     });
+  });
+
+  describe('browser build()', () => {
+
+    // A literal CR (or CR LF) in text content is normalized to a single LF
+    // when the plist is parsed back, so a CR must be encoded as `&#xD;` to
+    // round-trip. The Node `build()` already does this (via `xmlbuilder`).
+
+    it('should escape a carriage return so it survives a round-trip', () => {
+      const value = { note: 'line1\rline2' };
+      const xml = browserBuild(value);
+      expect(xml).toContain('line1&#xD;line2');
+      expect(parse(xml)).toEqual(value);
+    });
+
+    it('should escape a carriage return in a key', () => {
+      const value = { 'a\rb': 'c' };
+      expect(parse(browserBuild(value))).toEqual(value);
+    });
+
+    it('should match Node build() round-trip for a string containing CR LF', () => {
+      const value = { note: 'a\r\nb' };
+      expect(parse(browserBuild(value))).toEqual(value);
+      expect(parse(browserBuild(value))).toEqual(parse(build(value)));
+    });
+
   });
 
 });


### PR DESCRIPTION
The browser `build()` (`src/build.browser.ts`) escapes `&`, `<` and `>` but leaves a carriage return as a literal character. When the resulting plist is read back, the XML parser normalizes a literal CR (and CR LF) in text content to a single LF, so a string or key containing `\r` does not survive a round-trip through the browser builder:

```js
parse(build({ note: 'a\rb' }))   // -> { note: 'a\nb' }
```

The Node `build()` does not have this problem: it serializes text through `xmlbuilder`, which emits a carriage return as `&#xD;`, and a numeric character reference is exempt from line-ending normalization, so it round-trips. That means the two builders currently disagree for the same input.

This change escapes `\r` as `&#xD;` in the browser `escapeXml`, matching the Node builder's output. `\n` and `\t` are left as-is since they already round-trip (the Node builder does not escape them either).

Also added a few tests for the browser `build()` covering a CR in a string value, a CR in a key, and CR LF parity with the Node `build()`. The full test suite passes.
