### PR TITLE
fix: emit large integer-valued numbers as <real> to avoid silent corruption

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -83,7 +83,8 @@ function walk_obj(next: unknown, next_child: xmlbuilder.XMLElement): void {
       }
     }
   } else if (typeof next === 'number') {
-    const tag_type = next % 1 === 0 ? 'integer' : 'real';
+    const tag_type =
+      Number.isInteger(next) && Math.abs(next) < 1e21 ? 'integer' : 'real';
     next_child.ele(tag_type).txt(next.toString());
   } else if (typeof next === 'bigint') {
     next_child.ele('integer').txt(next.toString());

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -40,6 +40,12 @@ describe('parse()', () => {
       const parsed = parseFixture('<integer>14</integer>');
       expect(parsed).toBe(14);
     });
+
+    it('should round-trip integer-valued numbers >= 1e21', () => {
+      expect(parse(build(1e21))).toBe(1e21);
+      expect(parse(build(-1e21))).toBe(-1e21);
+      expect(parse(build(1.23e30))).toBe(1.23e30);
+    });
   });
 
   describe('real', () => {


### PR DESCRIPTION
## Problem

Integer-valued numbers with magnitude `>= 1e21` are silently corrupted on a `build` -> `parse` round-trip.

```js
plist.parse(plist.build(1e21))    // => 1      (expected 1e21)
plist.parse(plist.build(-1e21))   // => -1     (expected -1e21)
plist.parse(plist.build(1.23e30)) // => 1      (expected 1.23e30)
```

No error is thrown, so callers have no signal that 21+ orders of magnitude were lost.

## Cause

`build` classifies any integer-valued number as `<integer>` and serializes it with `Number.prototype.toString()`:

```ts
const tag_type = next % 1 === 0 ? 'integer' : 'real';
next_child.ele(tag_type).txt(next.toString());
```

For `|x| >= 1e21`, `toString()` returns exponential notation, e.g. `(1e21).toString() === "1e+21"`, producing `<integer>1e+21</integer>`. On parse, the `<integer>` branch does `parseInt(value, 10)`, which stops at the `e` and returns `1`.

The boundary is exactly `1e21`: values below it (including `1e20` and `562341325190349060000`) stringify in plain decimal and round-trip fine. The binary path (`buildBinary`/`parseBinary`) round-trips `1e21` correctly, so this is an XML-text serialization defect, not a representational limit.

Apple's PLIST DTD defines `<integer>` and `<real>` as the two numeric element types; a value that cannot be expressed as a plain-decimal integer string belongs in `<real>`.

## Fix

Classify a number as `<integer>` only when it is a true integer below the exponential threshold; otherwise emit `<real>`:

```ts
const tag_type =
  Number.isInteger(next) && Math.abs(next) < 1e21 ? 'integer' : 'real';
```

The `<real>` parse branch already uses `parseFloat`, which recovers `1e+21` exactly. Values below `1e21` keep the existing `<integer>` output, so there is no behavior change for the common case.

## Test

Added a round-trip test under `parse() > integer`. It fails on `master` (`expected 1 to be 1e+21`) and passes with the fix. Full suite: 113 passing.

## Note

`src/build.browser.ts` (line ~76) has the same classification logic and the same defect. I scoped this PR to the Node path that the repro exercises; let me know if you want the browser build fixed in this PR or a follow-up.
