### PR TITLE
Add browser test coverage

### DIFF
--- a/src/build.browser.ts
+++ b/src/build.browser.ts
@@ -85,7 +85,8 @@ export function build(obj: PlistValue, opts?: BuildOptions): string {
     } else if (typeof value === 'boolean') {
       emit(depth, value ? '<true/>' : '<false/>');
     } else if (typeof value === 'string') {
-      emit(depth, '<string>' + escapeXml(value) + '</string>');
+      const escaped = escapeXml(value);
+      emit(depth, escaped ? '<string>' + escaped + '</string>' : '<string/>');
     }
   }
 

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { build } from '../src/index.js';
+import { build as buildBrowser } from '../src/index.browser.js';
+import { build as buildNode } from '../src/index.js';
+
+const buildImplementations = [
+  ['node', buildNode],
+  ['browser', buildBrowser],
+] as const;
 
 describe('plist', () => {
 
-  describe('build()', () => {
+  describe.each(buildImplementations)('%s build()', (_, build) => {
 
     it('should create a plist XML string from a String', () => {
       const xml = build('test');


### PR DESCRIPTION
This runs the test suite against both Node.js and browser environments. Empty string serialization in the browser environment now matches Node.js.