### PR TITLE
Add invalidCharReplacement option

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Build an XML plist string.
 - **opts.pretty**: `boolean` (default: `true`) — pretty-print with indentation
 - **opts.indent**: `string` (default: `"  "`) — indentation string
 - **opts.newline**: `string` (default: `"\n"`) — newline string
+- **opts.invalidCharReplacement**: `string` — replace characters that are not valid in XML output. By default, invalid XML characters throw.
 - **returns**: `string`
 
 ### `buildBinary(obj)`

--- a/src/build.browser.ts
+++ b/src/build.browser.ts
@@ -15,11 +15,14 @@ export interface BuildOptions {
   pretty?: boolean;
   indent?: string;
   newline?: string;
+  invalidCharReplacement?: string;
 }
 
 const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8"?>';
 const DOCTYPE =
   '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">';
+const INVALID_XML_CHARS =
+  /[\0-\x08\x0B\f\x0E-\x1F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/g;
 
 /**
  * Generate an XML plist string from the input object `obj`.
@@ -32,6 +35,7 @@ export function build(obj: PlistValue, opts?: BuildOptions): string {
   const pretty = !opts || opts.pretty !== false;
   const indent = opts?.indent ?? '  ';
   const newline = opts?.newline ?? '\n';
+  const invalidCharReplacement = opts?.invalidCharReplacement;
 
   const lines: string[] = [];
 
@@ -66,7 +70,7 @@ export function build(obj: PlistValue, opts?: BuildOptions): string {
         if (Object.hasOwn(value as Record<string, unknown>, prop)) {
           const val = (value as Record<string, unknown>)[prop];
           if (val === undefined || val === null) continue;
-          emit(depth + 1, '<key>' + escapeXml(prop) + '</key>');
+          emit(depth + 1, '<key>' + escapeXml(prop, invalidCharReplacement) + '</key>');
           walk(val, depth + 1);
         }
       }
@@ -84,7 +88,7 @@ export function build(obj: PlistValue, opts?: BuildOptions): string {
     } else if (typeof value === 'boolean') {
       emit(depth, value ? '<true/>' : '<false/>');
     } else if (typeof value === 'string') {
-      emit(depth, '<string>' + escapeXml(value) + '</string>');
+      emit(depth, '<string>' + escapeXml(value, invalidCharReplacement) + '</string>');
     }
   }
 
@@ -104,9 +108,19 @@ export function build(obj: PlistValue, opts?: BuildOptions): string {
   return parts.join(sep);
 }
 
-function escapeXml(str: string): string {
-  return str
+function escapeXml(str: string, invalidCharReplacement?: string): string {
+  const escaped = str
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
+
+  if (invalidCharReplacement !== undefined) {
+    return escaped.replace(INVALID_XML_CHARS, invalidCharReplacement);
+  }
+
+  if (escaped.match(INVALID_XML_CHARS)) {
+    throw new Error(`Invalid character in string: ${escaped}`);
+  }
+
+  return escaped;
 }

--- a/src/build.browser.ts
+++ b/src/build.browser.ts
@@ -15,7 +15,6 @@ export interface BuildOptions {
   pretty?: boolean;
   indent?: string;
   newline?: string;
-  [key: string]: unknown;
 }
 
 const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8"?>';

--- a/src/build.ts
+++ b/src/build.ts
@@ -16,6 +16,7 @@ export interface BuildOptions {
   pretty?: boolean;
   indent?: string;
   newline?: string;
+  invalidCharReplacement?: string;
 }
 
 /**
@@ -36,7 +37,12 @@ export function build(obj: PlistValue, opts?: BuildOptions): string {
     sysid: 'http://www.apple.com/DTDs/PropertyList-1.0.dtd',
   };
 
-  const doc = xmlbuilder.create('plist');
+  const createOptions: xmlbuilder.CreateOptions = {};
+  if (opts?.invalidCharReplacement !== undefined) {
+    createOptions.invalidCharReplacement = opts.invalidCharReplacement;
+  }
+
+  const doc = xmlbuilder.create('plist', createOptions);
 
   doc.dec(XMLHDR.version, XMLHDR.encoding);
   doc.dtd(XMLDTD.pubid, XMLDTD.sysid);

--- a/src/build.ts
+++ b/src/build.ts
@@ -16,7 +16,6 @@ export interface BuildOptions {
   pretty?: boolean;
   indent?: string;
   newline?: string;
-  [key: string]: unknown;
 }
 
 /**
@@ -45,10 +44,14 @@ export function build(obj: PlistValue, opts?: BuildOptions): string {
 
   walk_obj(obj, doc);
 
-  if (!opts) opts = {};
   // default `pretty` to `true`
-  opts.pretty = opts.pretty !== false;
-  return doc.end(opts);
+  const xmlToStringOptions: xmlbuilder.XMLToStringOptions = {
+    pretty: opts?.pretty !== false,
+    ...(opts?.indent !== undefined && { indent: opts.indent }),
+    ...(opts?.newline !== undefined && { newline: opts.newline }),
+  };
+
+  return doc.end(xmlToStringOptions);
 }
 
 /**

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -140,6 +140,20 @@ describe('plist', () => {
       expect(xml).toContain('<string>🇺🇸🇯🇵</string>');
     });
 
+    it('should reject invalid XML characters by default', () => {
+      const content = { ['bad\u0001key']: 'hello\u0001world' };
+
+      expect(() => build(content)).toThrow(/Invalid character in string/);
+    });
+
+    it('should replace invalid XML characters with build options', () => {
+      const content = { ['bad\u0001key']: 'hello\u0001world' };
+
+      const xml = build(content, { invalidCharReplacement: '�' });
+      expect(xml).toContain('<key>bad�key</key>');
+      expect(xml).toContain('<string>hello�world</string>');
+    });
+
     it('should skip null values in arrays', () => {
       const xml = build([null, 'a', null]);
       expect(xml).toBe(`<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
This improves the xmlbuilder `XMLToStringOptions` types and adds the ability to use xmlbuilder `CreateOptions` with `invalidCharReplacement` added as an example.

At the moment, `[key: string]: unknown;` is used because `BuildOptions` doesn't align with `XMLToStringOptions`.